### PR TITLE
logout: do not require token

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -411,6 +411,7 @@ main_loop(void)
 	httpdAddCContent(webserver, "/wifidog", "about", 0, NULL, http_callback_about);
 	httpdAddCContent(webserver, "/wifidog", "status", 0, NULL, http_callback_status);
 	httpdAddCContent(webserver, "/wifidog", "auth", 0, NULL, http_callback_auth);
+	httpdAddCContent(webserver, "/wifidog", "logout", 0, NULL, http_callback_logout);
 
 	httpdAddC404Content(webserver, http_callback_404);
 

--- a/src/http.h
+++ b/src/http.h
@@ -39,6 +39,8 @@ void http_callback_about(httpd *webserver, request *r);
 void http_callback_status(httpd *webserver, request *r);
 /**@brief Callback for libhttpd, main entry point post login for auth confirmation */
 void http_callback_auth(httpd *webserver, request *r);
+/**@brief Callback for libhttpd */
+void http_callback_logout(httpd *webserver, request *r);
 
 /** @brief Sends a HTML page to web browser */
 void send_http_page(request *r, const char *title, const char* message);


### PR DESCRIPTION
The user wouldn't know his/her own token, so it doesn't make sense
to require it. The URL for logout is now simply /wifidog/logout.
