### PR TITLE
iptables_fw_init: fix memory leak

### DIFF
--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -367,6 +367,8 @@ iptables_fw_init(void)
 	iptables_do_command("-t filter -A " TABLE_WIFIDOG_UNKNOWN " -j REJECT --reject-with icmp-port-unreachable");
 
 	UNLOCK_CONFIG();
+
+	free(ext_interface);
 	return 1;
 }
 


### PR DESCRIPTION
ext_interface is always allocated from either safe_strdup or
get_ext_iface, but is never freed.

This is not much memory (and only occurs once), but fixing it keeps valgrind happy.
