### PR TITLE
Avoid deadlocks when the LOG_LEVEL is set to DEBUG

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <time.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "conf.h"
 
@@ -42,10 +43,14 @@ _debug(const char *filename, int line, int level, const char *format, ...)
     va_list vlist;
     s_config *config = config_get_config();
     time_t ts;
+    sigset_t block_chld;
 
     time(&ts);
 
     if (config->debuglevel >= level) {
+        sigemptyset(&block_chld);
+        sigaddset(&block_chld, SIGCHLD);
+        sigprocmask(SIG_BLOCK, &block_chld, NULL);
 
         if (level <= LOG_WARNING) {
             fprintf(stderr, "[%d][%.24s][%u](%s:%d) ", level, ctime_r(&ts, buf), getpid(),
@@ -70,7 +75,8 @@ _debug(const char *filename, int line, int level, const char *format, ...)
             vsyslog(level, format, vlist);
             va_end(vlist);
             closelog();
-        }
+
+            sigprocmask(SIG_UNBLOCK, &block_chld, NULL);
+	}
     }
 }
-


### PR DESCRIPTION
`fprintf` and `syslog` are thread-safe but not reentrant.
If a signal happen during those functions and the handler calling
them again, the deadlock is form.  Therefore, we need to block signals
until we leave they realm.

https://github.com/nodogsplash/nodogsplash/commit/89c1805d609b73c068fb78d045492103c16e6c74#diff-f5b46886ad081ff6ddf3a5b585346a02

patch by sayuan
