### PR TITLE
Use fprintf instead of printf, fixes help when building with uclibc

### DIFF
--- a/src/commandline.c
+++ b/src/commandline.c
@@ -57,18 +57,19 @@ pid_t restart_orig_pid = 0;
 static void
 usage(void)
 {
-    printf("Usage: wifidog [options]\n");
-    printf("\n");
-    printf("  -c [filename] Use this config file\n");
-    printf("  -f            Run in foreground\n");
-    printf("  -d <level>    Debug level\n");
-    printf("  -s            Log to syslog\n");
-    printf("  -w <path>     Wdctl socket path\n");
-    printf("  -h            Print usage\n");
-    printf("  -v            Print version information\n");
-    printf("  -x pid        Used internally by WiFiDog when re-starting itself *DO NOT ISSUE THIS SWITCH MANUAlLY*\n");
-    printf("  -i <path>     Internal socket path used when re-starting self\n");
-    printf("\n");
+    fprintf(stdout, "Usage: wifidog [options]\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "options:\n");
+    fprintf(stdout, "  -c [filename] Use this config file\n");
+    fprintf(stdout, "  -f            Run in foreground\n");
+    fprintf(stdout, "  -d <level>    Debug level\n");
+    fprintf(stdout, "  -s            Log to syslog\n");
+    fprintf(stdout, "  -w <path>     Wdctl socket path\n");
+    fprintf(stdout, "  -h            Print usage\n");
+    fprintf(stdout, "  -v            Print version information\n");
+    fprintf(stdout, "  -x pid        Used internally by WiFiDog when re-starting itself *DO NOT ISSUE THIS SWITCH MANUAlLY*\n");
+    fprintf(stdout, "  -i <path>     Internal socket path used when re-starting self\n");
+    fprintf(stdout, "\n");
 }
 
 /** Uses getopt() to parse the command line and set configuration values
@@ -126,7 +127,7 @@ void parse_commandline(int argc, char **argv) {
 				break;
 
 			case 'v':
-				printf("This is WiFiDog version " VERSION "\n");
+				fprintf(stdout, "This is WiFiDog version " VERSION "\n");
 				exit(1);
 				break;
 
@@ -136,7 +137,7 @@ void parse_commandline(int argc, char **argv) {
 					restart_orig_pid = atoi(optarg);
 				}
 				else {
-					printf("The expected PID to the -x switch was not supplied!");
+					fprintf(stdout, "The expected PID to the -x switch was not supplied!");
 					exit(1);
 				}
 				break;

--- a/src/wdctl.c
+++ b/src/wdctl.c
@@ -60,18 +60,18 @@ static void wdctl_restart(void);
 static void
 usage(void)
 {
-    printf("Usage: wdctl [options] command [arguments]\n");
-    printf("\n");
-    printf("options:\n");
-    printf("  -s <path>         Path to the socket\n");
-    printf("  -h                Print usage\n");
-    printf("\n");
-    printf("commands:\n");
-    printf("  reset [mac|ip]    Reset the specified mac or ip connection\n");
-    printf("  status            Obtain the status of wifidog\n");
-    printf("  stop              Stop the running wifidog\n");
-    printf("  restart           Re-start the running wifidog (without disconnecting active users!)\n");
-    printf("\n");
+    fprintf(stdout, "Usage: wdctl [options] command [arguments]\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "options:\n");
+    fprintf(stdout, "  -s <path>         Path to the socket\n");
+    fprintf(stdout, "  -h                Print usage\n");
+    fprintf(stdout, "\n");
+    fprintf(stdout, "commands:\n");
+    fprintf(stdout, "  reset [mac|ip]    Reset the specified mac or ip connection\n");
+    fprintf(stdout, "  status            Obtain the status of wifidog\n");
+    fprintf(stdout, "  stop              Stop the running wifidog\n");
+    fprintf(stdout, "  restart           Re-start the running wifidog (without disconnecting active users!)\n");
+    fprintf(stdout, "\n");
 }
 
 /** @internal
@@ -202,7 +202,7 @@ wdctl_status(void)
 	
 	while ((len = read(sock, buffer, sizeof(buffer))) > 0) {
 		buffer[len] = '\0';
-		printf("%s", buffer);
+		fprintf(stdout, "%s", buffer);
 	}
 
 	shutdown(sock, 2);
@@ -225,7 +225,7 @@ wdctl_stop(void)
 	
 	while ((len = read(sock, buffer, sizeof(buffer))) > 0) {
 		buffer[len] = '\0';
-		printf("%s", buffer);
+		fprintf(stdout, "%s", buffer);
 	}
 
 	shutdown(sock, 2);
@@ -257,9 +257,9 @@ wdctl_reset(void)
 	}
 
 	if (strcmp(buffer, "Yes") == 0) {
-		printf("Connection %s successfully reset.\n", config.param);
+		fprintf(stdout, "Connection %s successfully reset.\n", config.param);
 	} else if (strcmp(buffer, "No") == 0) {
-		printf("Connection %s was not active.\n", config.param);
+		fprintf(stdout, "Connection %s was not active.\n", config.param);
 	} else {
 		fprintf(stderr, "wdctl: Error: WiFiDog sent an abnormal "
 				"reply.\n");
@@ -285,7 +285,7 @@ wdctl_restart(void)
 	
 	while ((len = read(sock, buffer, sizeof(buffer))) > 0) {
 		buffer[len] = '\0';
-		printf("%s", buffer);
+		fprintf(stdout, "%s", buffer);
 	}
 
 	shutdown(sock, 2);


### PR DESCRIPTION
IMO this is better then define NEED_PRINTF globally.