### PR TITLE
Fix segfault when receiving invalid auth reply

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -160,7 +160,7 @@ authenticate_client(request *r)
 
 	case AUTH_ERROR:
 		/* Error talking to central server */
-		debug(LOG_ERR, "Got %d from central server authenticating token %s from %s at %s", auth_response, client->token, client->ip, client->mac);
+		debug(LOG_ERR, "Got ERROR from central server authenticating token %s from %s at %s", client->token, client->ip, client->mac);
 		send_http_page(r, "Error!", "Error: We did not get a valid answer from the central server");
 		break;
 


### PR DESCRIPTION
auth_response is the structure causing segfault when used as an int

Using "ERROR" instead of the auth code for readability and to
match other logs