### PR TITLE
Enable the use of -Wall and fix resulting warning

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,8 @@ bin_PROGRAMS = wifidog \
  
 AM_CPPFLAGS = \
 	-I${top_srcdir}/libhttpd/ \
-	-DSYSCONFDIR='"$(sysconfdir)"' 
+	-DSYSCONFDIR='"$(sysconfdir)"' \
+	-Wall
 wifidog_LDADD = $(top_builddir)/libhttpd/libhttpd.la
 
 wifidog_SOURCES = commandline.c \

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -145,14 +145,14 @@ iptables_compile(const char * table, const char *chain, const t_firewall_rule *r
 	case TARGET_DROP:
 		if (strncmp(table, "nat", 3) == 0) {
 			free(mode);
-			return;
+			return NULL;
 		}
 		mode = safe_strdup("DROP");
 		break;
 	case TARGET_REJECT:
 		if (strncmp(table, "nat", 3) == 0) {
 			free(mode);
-			return;
+			return NULL;
 		}
 		mode = safe_strdup("REJECT");
 		break;

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -143,14 +143,14 @@ iptables_compile(const char * table, const char *chain, const t_firewall_rule *r
 
 	switch (rule->target){
 	case TARGET_DROP:
-		if (table=="nat") {
+		if (strncmp(table, "nat", 3) == 0) {
 			free(mode);
 			return;
 		}
 		mode = safe_strdup("DROP");
 		break;
 	case TARGET_REJECT:
-		if (table=="nat") {
+		if (strncmp(table, "nat", 3) == 0) {
 			free(mode);
 			return;
 		}

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -140,6 +140,7 @@ iptables_compile(const char * table, const char *chain, const t_firewall_rule *r
 		*mode;
 
 	memset(command, 0, MAX_BUF);
+	mode = NULL;
 
 	switch (rule->target){
 	case TARGET_DROP:

--- a/src/wdctl_thread.c
+++ b/src/wdctl_thread.c
@@ -65,6 +65,8 @@ static void wdctl_stop(int);
 static void wdctl_reset(int, const char *);
 static void wdctl_restart(int);
 
+static int wdctl_socket_server;
+
 /** Launches a thread that monitors the control socket for request
 @param arg Must contain a pointer to a string containing the Unix domain socket to open
 @todo This thread loops infinitely, need a watchdog to verify that it is still running?

--- a/src/wdctl_thread.h
+++ b/src/wdctl_thread.h
@@ -29,8 +29,6 @@
 
 #define DEFAULT_WDCTL_SOCK	"/tmp/wdctl.sock"
 
-static int wdctl_socket_server;
-
 /** @brief Listen for WiFiDog control messages on a unix domain socket */
 void thread_wdctl(void *arg);
 


### PR DESCRIPTION
This is a cherry pick of 3 of @mhaas's commits along with a tweak to automake and another fix.

The libhttpd code is explicitly not included in the -Wall goodness. That code needs a flame thrower.