### PR TITLE
Fix a memory leak of arp_get() output.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -133,6 +133,7 @@ http_callback_404(httpd *webserver, request *r)
 				r->clientAddr,
 				mac,
 				url);
+            free(mac);
 		}
 
                 debug(LOG_INFO, "Check host %s is in whitelist or not", r->request.host); // eg. www.example.com


### PR DESCRIPTION
http.c failed to free the mac address in the 404 call back. Leaking one mac address worth of heap on every HTTP request.