### PR TITLE
Fix double free

### DIFF
--- a/src/wdctl_thread.c
+++ b/src/wdctl_thread.c
@@ -323,7 +323,6 @@ wdctl_restart(int afd)
 				written = write(fd, (tempstring + len), strlen(tempstring) - len);
 				if (written == -1) {
 					debug(LOG_ERR, "Failed to write client data to child: %s", strerror(errno));
-					free(tempstring);
 					break;
 				}
 				else {


### PR DESCRIPTION
/usr/share/clang/scan-build-3.5/ccc-analyzer -DHAVE_CONFIG_H -I. -I..  -I../libhttpd/ -DSYSCONFDIR='"/usr/local/etc"' -Wall   -g -O2 -MT wdctl_thread.o -MD -MP -MF .deps/wdctl_thread.Tpo -c -o wdctl_thread.o wdctl_thread.c
wdctl_thread.c:333:4: warning: Attempt to free released memory
                        free(tempstring);
                        ^~~~~~~~~~~~~~~~