### PR TITLE
Remove NetBSD code and assume __linux__ always.

### DIFF
--- a/src/firewall.c
+++ b/src/firewall.c
@@ -50,18 +50,10 @@
 #include <netdb.h>
 #include <sys/time.h>
 
-#ifdef __linux__
 #include <net/ethernet.h>
 #include <netinet/ip.h>
 #include <netinet/ip_icmp.h>
 #include <netpacket/packet.h>
-#endif
-
-#if defined(__NetBSD__)
-#include <netinet/in_systm.h>
-#include <netinet/ip.h>
-#include <netinet/ip_icmp.h>
-#endif
 
 #include "httpd.h"
 #include "safe.h"
@@ -371,12 +363,10 @@ void
 icmp_ping(const char *host)
 {
 	struct sockaddr_in saddr;
-#if defined(__linux__) || defined(__NetBSD__)
 	struct {
 		struct ip ip;
 		struct icmp icmp;
 	} packet;
-#endif
 	unsigned int i, j;
 	int opt = 2000;
 	unsigned short id = rand16();
@@ -384,11 +374,10 @@ icmp_ping(const char *host)
 	memset(&saddr, 0, sizeof(saddr));
 	saddr.sin_family = AF_INET;
 	inet_aton(host, &saddr.sin_addr);
-#if defined(HAVE_SOCKADDR_SA_LEN) || defined(__NetBSD__)
+#if defined(HAVE_SOCKADDR_SA_LEN)
 	saddr.sin_len = sizeof(struct sockaddr_in);
 #endif
 
-#if defined(__linux__) || defined(__NetBSD__)
 	memset(&packet.icmp, 0, sizeof(packet.icmp));
 	packet.icmp.icmp_type = ICMP_ECHO;
 	packet.icmp.icmp_id = id;
@@ -411,7 +400,6 @@ icmp_ping(const char *host)
 	opt = 1;
 	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
 		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
-#endif
 
 	return;
 }

--- a/src/http.c
+++ b/src/http.c
@@ -26,10 +26,8 @@
   @author Copyright (C) 2007 David Bird <david@coova.com>
 
  */
-#if defined(__linux__)
 /* Note that libcs other than GLIBC also use this macro to enable vasprintf */
 #define _GNU_SOURCE
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/util.c
+++ b/src/util.c
@@ -42,18 +42,8 @@
 #include <sys/ioctl.h>
 #include <arpa/inet.h>
 
-#if defined(__NetBSD__)
-#include <sys/socket.h>
-#include <ifaddrs.h>
-#include <net/if.h>
-#include <net/if_dl.h>
-#include <util.h>
-#endif
-
-#ifdef __linux__
 #include <netinet/in.h>
 #include <net/if.h>
-#endif
 
 #include <string.h>
 #include <pthread.h>
@@ -161,7 +151,6 @@ wd_gethostbyname(const char *name)
 	char *
 get_iface_ip(const char *ifname)
 {
-#if defined(__linux__)
 	struct ifreq if_data;
 	struct in_addr in;
 	char *ip_str;
@@ -188,38 +177,11 @@ get_iface_ip(const char *ifname)
 	ip_str = inet_ntoa(in);
 	close(sockd);
 	return safe_strdup(ip_str);
-#elif defined(__NetBSD__)
-	struct ifaddrs *ifa, *ifap;
-	char *str = NULL;
-
-	if (getifaddrs(&ifap) == -1) {
-		debug(LOG_ERR, "getifaddrs(): %s", strerror(errno));
-		return NULL;
-	}
-	/* XXX arbitrarily pick the first IPv4 address */
-	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-		if (strcmp(ifa->ifa_name, ifname) == 0 &&
-				ifa->ifa_addr->sa_family == AF_INET)
-			break;
-	}
-	if (ifa == NULL) {
-		debug(LOG_ERR, "%s: no IPv4 address assigned");
-		goto out;
-	}
-	str = safe_strdup(inet_ntoa(
-				((struct sockaddr_in *)ifa->ifa_addr)->sin_addr));
-out:
-	freeifaddrs(ifap);
-	return str;
-#else
-	return safe_strdup("0.0.0.0");
-#endif
 }
 
 	char *
 get_iface_mac(const char *ifname)
 {
-#if defined(__linux__)
 	int r, s;
 	struct ifreq ifr;
 	char *hwaddr, mac[13];
@@ -251,45 +213,11 @@ get_iface_mac(const char *ifname)
 		);
 
 	return safe_strdup(mac);
-#elif defined(__NetBSD__)
-	struct ifaddrs *ifa, *ifap;
-	const char *hwaddr;
-	char mac[13], *str = NULL;
-	struct sockaddr_dl *sdl;
-
-	if (getifaddrs(&ifap) == -1) {
-		debug(LOG_ERR, "getifaddrs(): %s", strerror(errno));
-		return NULL;
-	}
-	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-		if (strcmp(ifa->ifa_name, ifname) == 0 &&
-				ifa->ifa_addr->sa_family == AF_LINK)
-			break;
-	}
-	if (ifa == NULL) {
-		debug(LOG_ERR, "%s: no link-layer address assigned");
-		goto out;
-	}
-	sdl = (struct sockaddr_dl *)ifa->ifa_addr;
-	hwaddr = LLADDR(sdl);
-	snprintf(mac, sizeof(mac), "%02X%02X%02X%02X%02X%02X",
-			hwaddr[0] & 0xFF, hwaddr[1] & 0xFF,
-			hwaddr[2] & 0xFF, hwaddr[3] & 0xFF,
-			hwaddr[4] & 0xFF, hwaddr[5] & 0xFF);
-
-	str = safe_strdup(mac);
-out:
-	freeifaddrs(ifap);
-	return str;
-#else
-	return NULL;
-#endif
 }
 
 	char *
 get_ext_iface(void)
 {
-#ifdef __linux__
 	FILE *input;
 	char *device, *gw;
 	int i = 1;
@@ -331,7 +259,6 @@ get_ext_iface(void)
 	exit(1); /* XXX Should this be termination handler? */
 	free(device);
 	free(gw);
-#endif
 	return NULL;
 }
 


### PR DESCRIPTION
Basically, the NetBSD part was incomplete, unmaintained and the
original code is lost to URL rot. Linux is still the only
supported platform.