### PR TITLE
Fix the build since README was removed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 # $Id$
 
+AUTOMAKE_OPTIONS = foreign
+
 SUBDIRS = libhttpd src . doc 
 
 docdir = ${prefix}/share/doc/wifidog-@VERSION@
@@ -9,7 +11,7 @@ doc_DATA = \
   COPYING \
   INSTALL \
   NEWS \
-  README \
+  README.md \
   ChangeLog
   
 EXTRA_DIST = \


### PR DESCRIPTION
Turns out that without README file, we are not a proper GNU project and automake will refuse to generate Makefile. This is the root cause of issue #123.