### PR TITLE
Remove dependency on INSTALL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ docdir = ${prefix}/share/doc/wifidog-@VERSION@
 doc_DATA = \
   AUTHORS \
   COPYING \
-  INSTALL \
   NEWS \
   README.md \
   ChangeLog


### PR DESCRIPTION
This was also being required by Makefile.am and was removed in 1.2.0...

Could only build on a "dirty" directory that already contained an untracked INSTALL.