### PR TITLE
Add clang and CyaSSL to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ install:
 script:
   - ./.travis_configure_wrapper.sh && make
 env:
-  - BUILD_TYPE=normal
-  - CYASSL="3.3.2" BUILD_TYPE=cyassl
+  global:
+    - CFLAGS="-Werror"
+  matrix: 
+    - BUILD_TYPE=normal
+    - CYASSL="3.3.2" BUILD_TYPE=cyassl
 cache:
   directories:
     - dependencies-src

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
+# Use newer, container based infrastructure
+# Does not allow use of apt-get, but enables
+# caching support
+sudo: false
 language: c
 compiler:
   - gcc
+  - clang
 install:
   - ./autogen.sh
 script:
-  - ./configure && make
+  - ./.travis_configure_wrapper.sh && make
+env:
+  - BUILD_TYPE=normal
+  - CYASSL="3.3.2" BUILD_TYPE=cyassl
+cache:
+  directories:
+    - dependencies-src
+    - dependencies-installed

--- a/.travis_configure_wrapper.sh
+++ b/.travis_configure_wrapper.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+if [[ -z "$BUILD_TYPE" ]]; then
+    echo "BUILD_TYPE not set. Bye."
+    exit 1
+fi
+
+if [[ "$BUILD_TYPE" == "normal" ]]; then
+
+    echo "Running Wifidog configure"
+    ./configure $@
+
+elif [[ "$BUILD_TYPE" == "cyassl" ]]; then
+    if [[ -z "$CYASSL" ]]; then
+        echo "CYASSL not set."
+        exit 1
+    fi
+    CUR=`pwd`
+    mkdir -p dependencies-src || true
+    mkdir -p dependencies-installed || true
+    if [[ ! -f dependencies-installed/include/cyassl/ssl.h ]]; then
+        echo "Cached CyaSSL install not found. Installing."
+        cd dependencies-src
+        # Check if travis cache is there
+        if [[ -f cyassl-${CYASSL}/autogen.sh ]]; then
+            echo "Found cached CyaSSL package"
+        else
+            echo "No cache, downloading CyaSSL"
+            wget https://github.com/cyassl/cyassl/archive/v${CYASSL}.tar.gz \
+                -O cyassl-${CYASSL}.tar.gz
+            tar -xzf cyassl-${CYASSL}.tar.gz
+        fi
+        cd cyassl-${CYASSL}
+        echo "Content of cyassl-${CYASSL}:"
+        ls
+        echo "Running CyaSSL autogen.sh"
+        ./autogen.sh
+        echo "Running CyaSSL configure"
+        ./configure --prefix="$CUR"/dependencies-installed/ --enable-ecc
+        # make will pick up the cached object files - real savings
+        # happen here
+        echo "Running CyaSSL make"
+        make
+        echo "Running CyaSSL make install"
+        make install
+        cd "$CUR"
+    else
+        echo "Cached CyaSSL install found."
+    fi
+    echo "Running Wifidog configure"
+    export CFLAGS="-I${CUR}/dependencies-installed/include/"
+    export LDFLAGS="-L${CUR}/dependencies-installed/lib/"
+    ./configure --enable-cyassl $@
+else
+    echo "Unknow BUILD_TYPE $BUILD_TYPE"
+    exit 1
+fi

--- a/libhttpd/ip_acl.c
+++ b/libhttpd/ip_acl.c
@@ -122,7 +122,8 @@ char *cidr;
 int action;
 {
     httpAcl *cur;
-    int addr, len;
+    unsigned int addr;
+    unsigned int len;
 
     /*
      ** Check the ACL info is reasonable
@@ -165,7 +166,9 @@ int
 httpdCheckAcl(httpd * server, request * r, httpAcl * acl)
 {
     httpAcl *cur;
-    int addr, len, res, action;
+    unsigned int addr;
+    unsigned int len;
+    int res, action;
 
     action = HTTP_ACL_DENY;
     res = scanCidr(r->clientAddr, &addr, &len); /* Returns -1 on conversion failure. */

--- a/libhttpd/protocol.c
+++ b/libhttpd/protocol.c
@@ -256,8 +256,7 @@ int outbufsize;
 }
 
 char
-_httpd_from_hex(c)
-char c;
+_httpd_from_hex(char c)
 {
     return c >= '0' && c <= '9' ? c - '0' : c >= 'A' && c <= 'F' ? c - 'A' + 10 : c - 'a' + 10; /* accept small letters just in case */
 }

--- a/src/conf.c
+++ b/src/conf.c
@@ -863,7 +863,10 @@ void parse_trusted_mac_list(const char *ptr) {
 					config.trustedmaclist->next = NULL;
 				} else {
 				/* Advance to the last entry */
-				for (p = config.trustedmaclist; p->next != NULL; p = p->next);
+				p = config.trustedmaclist;
+				while (p->next != NULL) {
+					p = p->next;
+				}
 				p->next = safe_malloc(sizeof(t_trusted_mac));
 				p = p->next;
 				p->mac = safe_strdup(mac);

--- a/src/conf.c
+++ b/src/conf.c
@@ -863,13 +863,13 @@ void parse_trusted_mac_list(const char *ptr) {
 					config.trustedmaclist->next = NULL;
 				} else {
 				/* Advance to the last entry */
-				for (p = config.trustedmaclist; p->next != NULL; p = p->next) {
-					p->next = safe_malloc(sizeof(t_trusted_mac));
-					p = p->next;
-					p->mac = safe_strdup(mac);
-					p->next = NULL;
-					}
+				for (p = config.trustedmaclist; p->next != NULL; p = p->next);
+				p->next = safe_malloc(sizeof(t_trusted_mac));
+				p = p->next;
+				p->mac = safe_strdup(mac);
+				p->next = NULL;
 				}
+			}
 		}
 	}
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -863,13 +863,13 @@ void parse_trusted_mac_list(const char *ptr) {
 					config.trustedmaclist->next = NULL;
 				} else {
 				/* Advance to the last entry */
-				for (p = config.trustedmaclist; p->next != NULL; p = p->next);
-				p->next = safe_malloc(sizeof(t_trusted_mac));
-				p = p->next;
-				p->mac = safe_strdup(mac);
-				p->next = NULL;
+				for (p = config.trustedmaclist; p->next != NULL; p = p->next) {
+					p->next = safe_malloc(sizeof(t_trusted_mac));
+					p = p->next;
+					p->mac = safe_strdup(mac);
+					p->next = NULL;
+					}
 				}
-			}
 		}
 	}
 


### PR DESCRIPTION
We use the travis cache to avoid re-building CyaSSL.

On a cold cache, CyaSSL is downloaded from github into dependencies-src/
and installed into dependencies-installed/. Both directories are added to the
Travis cache.