### PR TITLE
Remove ancient buildroot support from autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -9,30 +9,6 @@ then
 	make distclean
 fi
 
-if [ "X$1" != "X" ]
-then
-	BUILDROOT=`echo "$1" | sed 's/^[^=]*[=]//'`
-
-	OLDCC=${CC}
-	OLDRANLIB=${RANLIB}
-	OLDAR=${AR}
-
-	CC=${BUILDROOT}/build_mipsel/staging_dir/bin/mipsel-linux-uclibc-gcc
-	RANLIB=${BUILDROOT}/build_mipsel/staging_dir/bin/mipsel-linux-uclibc-ranlib
-	AR=${BUILDROOT}/build_mipsel/staging_dir/bin/mipsel-linux-uclibc-ar
-
-	POSTCONF=--host=mipsel
-
-	export CC
-	export RANLIB
-	export AR
-else
-	OLDCC=${CC}
-	OLDRANLIB=${RANLIB}
-	OLDAR=${AR}
-	POSTCONF=
-fi
-
 echo "Running mkdir -p config"
 mkdir -p config
 
@@ -55,11 +31,3 @@ echo "Running autoconf"
 autoconf
 echo "Running ./configure ${POSTCONF} --enable-maintainer-mode  $conf_flags $@"
 ./configure ${POSTCONF} --enable-maintainer-mode $conf_flags "$@"
-
-CC=${OLDCC}
-RANLIB=${OLDRANLIB}
-AR=${OLDAR}
-
-export CC
-export RANLIB
-export AR


### PR DESCRIPTION
This should resolve #103 if I understand right. Someone that actually uses build root and builds ipks should confirm (!)