### PR TITLE
Libhttpd fixes

### DIFF
--- a/libhttpd/api.c
+++ b/libhttpd/api.c
@@ -686,7 +686,8 @@ httpdSetResponse(request * r, const char *msg)
 void
 httpdSetContentType(request * r, const char *type)
 {
-    strcpy(r->response.contentType, type);
+    strncpy(r->response.contentType, type, HTTP_MAX_URL - 1);
+    r->response.contentType[HTTP_MAX_URL - 1] = 0;
 }
 
 void

--- a/libhttpd/protocol.c
+++ b/libhttpd/protocol.c
@@ -321,11 +321,11 @@ _httpd_storeData(request * r, char *query)
     if (!query)
         return;
 
-    var = (char *)malloc(strlen(query));
+    var = (char *)malloc(strlen(query) + 1);
 
     cp = query;
     cp2 = var;
-    bzero(var, strlen(query));
+    bzero(var, strlen(query) + 1);
     val = NULL;
     while (*cp) {
         if (*cp == '=') {


### PR DESCRIPTION
All issues that coverity found:

* No error check on setsockopt
* Two strcpy into fixed-sized buffers
* Possibly non-terminanted string
* httpd_output variable expansion could exceed buffer length
* va_end() not called