### PR TITLE
Fix coverity false-positive

### DIFF
--- a/src/wdctl_thread.c
+++ b/src/wdctl_thread.c
@@ -249,6 +249,7 @@ wdctl_status(int fd)
 }
 
 /** A bit of an hack, self kills.... */
+/* coverity[+kill] */
 static void
 wdctl_stop(int fd)
 {


### PR DESCRIPTION
Coverity does not realize wdctl_stop() always terminates, adding special comment to identify this.