### PR TITLE
Refactor http_get and https_get to not reuse memory

### DIFF
--- a/src/centralserver.c
+++ b/src/centralserver.c
@@ -1,3 +1,4 @@
+/* vim: set sw=4 ts=4 sts=4 et : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -51,7 +52,7 @@
 
 #include "simple_http.h"
 
-extern pthread_mutex_t	config_mutex;
+extern pthread_mutex_t config_mutex;
 
 /** Initiates a transaction with the auth server, either to authenticate or to
  * update the traffic counters at the server
@@ -64,276 +65,271 @@ extern pthread_mutex_t	config_mutex;
 @param outgoing Current counter of the client's total outgoing traffic, in bytes 
 */
 t_authcode
-auth_server_request(t_authresponse *authresponse, const char *request_type, const char *ip, const char *mac,
-        const char *token, unsigned long long int incoming, unsigned long long int outgoing)
+auth_server_request(t_authresponse * authresponse, const char *request_type, const char *ip, const char *mac,
+                    const char *token, unsigned long long int incoming, unsigned long long int outgoing)
 {
-	int sockfd;
-	char buf[MAX_BUF];
-	char *tmp;
-	char *safe_token;
-	t_auth_serv	*auth_server = NULL;
-	auth_server = get_auth_server();
-	
-	/* Blanket default is error. */
-	authresponse->authcode = AUTH_ERROR;
-	
-	sockfd = connect_auth_server();
+    int sockfd;
+    char buf[MAX_BUF];
+    char *tmp;
+    char *safe_token;
+    t_auth_serv *auth_server = NULL;
+    auth_server = get_auth_server();
 
-	/**
+    /* Blanket default is error. */
+    authresponse->authcode = AUTH_ERROR;
+
+    sockfd = connect_auth_server();
+
+        /**
 	 * TODO: XXX change the PHP so we can harmonize stage as request_type
 	 * everywhere.
 	 */
-	memset(buf, 0, sizeof(buf));
-	safe_token=httpdUrlEncode(token);
-	snprintf(buf, (sizeof(buf) - 1),
-		"GET %s%sstage=%s&ip=%s&mac=%s&token=%s&incoming=%llu&outgoing=%llu&gw_id=%s HTTP/1.0\r\n"
-		"User-Agent: WiFiDog %s\r\n"
-		"Host: %s\r\n"
-		"\r\n",
-		auth_server->authserv_path,
-		auth_server->authserv_auth_script_path_fragment,
-		request_type,
-		ip,
-		mac,
-		safe_token,
-		incoming,
-		outgoing,
-		config_get_config()->gw_id,
-		VERSION,
-		auth_server->authserv_hostname
-	);
+    memset(buf, 0, sizeof(buf));
+    safe_token = httpdUrlEncode(token);
+    snprintf(buf, (sizeof(buf) - 1),
+             "GET %s%sstage=%s&ip=%s&mac=%s&token=%s&incoming=%llu&outgoing=%llu&gw_id=%s HTTP/1.0\r\n"
+             "User-Agent: WiFiDog %s\r\n"
+             "Host: %s\r\n"
+             "\r\n",
+             auth_server->authserv_path,
+             auth_server->authserv_auth_script_path_fragment,
+             request_type,
+             ip,
+             mac, safe_token, incoming, outgoing, config_get_config()->gw_id, VERSION, auth_server->authserv_hostname);
 
-	free(safe_token);
+    free(safe_token);
 
-	char *res;
-	#ifdef USE_CYASSL
-	if (auth_server->authserv_use_ssl) {
-		res = https_get(sockfd, buf, auth_server->authserv_hostname);
-	} else {
-		res = http_get(sockfd, buf);
-	}
-	#endif
-	#ifndef USE_CYASSL
-	res = http_get(sockfd, buf);
-	#endif
-	if (NULL == res) {
-		debug(LOG_ERR, "There was a problem talking to the auth server!");
-		return (AUTH_ERROR);
-	}
-	
-	if ((tmp = strstr(res, "Auth: "))) {
-		if (sscanf(tmp, "Auth: %d", (int *)&authresponse->authcode) == 1) {
-			debug(LOG_INFO, "Auth server returned authentication code %d", authresponse->authcode);
+    char *res;
+#ifdef USE_CYASSL
+    if (auth_server->authserv_use_ssl) {
+        res = https_get(sockfd, buf, auth_server->authserv_hostname);
+    } else {
+        res = http_get(sockfd, buf);
+    }
+#endif
+#ifndef USE_CYASSL
+    res = http_get(sockfd, buf);
+#endif
+    if (NULL == res) {
+        debug(LOG_ERR, "There was a problem talking to the auth server!");
+        return (AUTH_ERROR);
+    }
+
+    if ((tmp = strstr(res, "Auth: "))) {
+        if (sscanf(tmp, "Auth: %d", (int *)&authresponse->authcode) == 1) {
+            debug(LOG_INFO, "Auth server returned authentication code %d", authresponse->authcode);
             free(res);
-			return(authresponse->authcode);
-		} else {
-			debug(LOG_WARNING, "Auth server did not return expected authentication code");
+            return (authresponse->authcode);
+        } else {
+            debug(LOG_WARNING, "Auth server did not return expected authentication code");
             free(res);
-			return(AUTH_ERROR);
-		}
-	}
+            return (AUTH_ERROR);
+        }
+    }
     free(res);
-	return(AUTH_ERROR);
+    return (AUTH_ERROR);
 }
 
 /* Tries really hard to connect to an auth server. Returns a file descriptor, -1 on error
  */
-int connect_auth_server() {
-	int sockfd;
+int
+connect_auth_server()
+{
+    int sockfd;
 
-	LOCK_CONFIG();
-	sockfd = _connect_auth_server(0);
-	UNLOCK_CONFIG();
+    LOCK_CONFIG();
+    sockfd = _connect_auth_server(0);
+    UNLOCK_CONFIG();
 
-	if (sockfd == -1) {
-		debug(LOG_ERR, "Failed to connect to any of the auth servers");
-		mark_auth_offline();
-	}
-	else {
-		debug(LOG_DEBUG, "Connected to auth server");
-		mark_auth_online();
-	}
-	return (sockfd);
+    if (sockfd == -1) {
+        debug(LOG_ERR, "Failed to connect to any of the auth servers");
+        mark_auth_offline();
+    } else {
+        debug(LOG_DEBUG, "Connected to auth server");
+        mark_auth_online();
+    }
+    return (sockfd);
 }
 
 /* Helper function called by connect_auth_server() to do the actual work including recursion
  * DO NOT CALL DIRECTLY
  @param level recursion level indicator must be 0 when not called by _connect_auth_server()
  */
-int _connect_auth_server(int level) {
-	s_config *config = config_get_config();
-	t_auth_serv *auth_server = NULL;
-	struct in_addr *h_addr;
-	int num_servers = 0;
-	char * hostname = NULL;
-	char * popular_servers[] = {
-		  "www.google.com",
-		  "www.yahoo.com",
-		  NULL
-	};
-	char ** popularserver;
-	char * ip;
-	struct sockaddr_in their_addr;
-	int sockfd;
+int
+_connect_auth_server(int level)
+{
+    s_config *config = config_get_config();
+    t_auth_serv *auth_server = NULL;
+    struct in_addr *h_addr;
+    int num_servers = 0;
+    char *hostname = NULL;
+    char *popular_servers[] = {
+        "www.google.com",
+        "www.yahoo.com",
+        NULL
+    };
+    char **popularserver;
+    char *ip;
+    struct sockaddr_in their_addr;
+    int sockfd;
 
     /* If there are no auth servers, error out, from scan-build warning. */
     if (NULL == config->auth_servers) {
-        return(-1);
+        return (-1);
     }
 
-	/* XXX level starts out at 0 and gets incremented by every iterations. */
-	level++;
+    /* XXX level starts out at 0 and gets incremented by every iterations. */
+    level++;
 
-	/*
-	 * Let's calculate the number of servers we have
-	 */
-	for (auth_server = config->auth_servers; auth_server; auth_server = auth_server->next) {
-		num_servers++;
-	}
-	debug(LOG_DEBUG, "Level %d: Calculated %d auth servers in list", level, num_servers);
+    /*
+     * Let's calculate the number of servers we have
+     */
+    for (auth_server = config->auth_servers; auth_server; auth_server = auth_server->next) {
+        num_servers++;
+    }
+    debug(LOG_DEBUG, "Level %d: Calculated %d auth servers in list", level, num_servers);
 
-	if (level > num_servers) {
-		/*
-		 * We've called ourselves too many times
-		 * This means we've cycled through all the servers in the server list
-		 * at least once and none are accessible
-		 */
-		return (-1);
-	}
+    if (level > num_servers) {
+        /*
+         * We've called ourselves too many times
+         * This means we've cycled through all the servers in the server list
+         * at least once and none are accessible
+         */
+        return (-1);
+    }
 
-	/*
-	 * Let's resolve the hostname of the top server to an IP address
-	 */
-	auth_server = config->auth_servers;
-	hostname = auth_server->authserv_hostname;
-	debug(LOG_DEBUG, "Level %d: Resolving auth server [%s]", level, hostname);
-	h_addr = wd_gethostbyname(hostname);
-	if (!h_addr) {
-		/*
-		 * DNS resolving it failed
-		 *
-		 * Can we resolve any of the popular servers ?
-		 */
-		debug(LOG_DEBUG, "Level %d: Resolving auth server [%s] failed", level, hostname);
+    /*
+     * Let's resolve the hostname of the top server to an IP address
+     */
+    auth_server = config->auth_servers;
+    hostname = auth_server->authserv_hostname;
+    debug(LOG_DEBUG, "Level %d: Resolving auth server [%s]", level, hostname);
+    h_addr = wd_gethostbyname(hostname);
+    if (!h_addr) {
+        /*
+         * DNS resolving it failed
+         *
+         * Can we resolve any of the popular servers ?
+         */
+        debug(LOG_DEBUG, "Level %d: Resolving auth server [%s] failed", level, hostname);
 
-		for (popularserver = popular_servers; *popularserver; popularserver++) {
-			debug(LOG_DEBUG, "Level %d: Resolving popular server [%s]", level, *popularserver);
-			h_addr = wd_gethostbyname(*popularserver);
-			if (h_addr) {
-				debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] succeeded = [%s]", level, *popularserver, inet_ntoa(*h_addr));
-				break;
-			}
-			else {
-				debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] failed", level, *popularserver);
-			}
-		}
+        for (popularserver = popular_servers; *popularserver; popularserver++) {
+            debug(LOG_DEBUG, "Level %d: Resolving popular server [%s]", level, *popularserver);
+            h_addr = wd_gethostbyname(*popularserver);
+            if (h_addr) {
+                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] succeeded = [%s]", level, *popularserver,
+                      inet_ntoa(*h_addr));
+                break;
+            } else {
+                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] failed", level, *popularserver);
+            }
+        }
 
-		/* 
-		 * If we got any h_addr buffer for one of the popular servers, in other
-		 * words, if one of the popular servers resolved, we'll assume the DNS
-		 * works, otherwise we'll deal with net connection or DNS failure.
-		 */
-		if (h_addr) {
-			free (h_addr);
-			/*
-			 * Yes
-			 *
-			 * The auth server's DNS server is probably dead. Try the next auth server
-			 */
-			debug(LOG_DEBUG, "Level %d: Marking auth server [%s] as bad and trying next if possible", level, hostname);
-			if (auth_server->last_ip) {
-				free(auth_server->last_ip);
-				auth_server->last_ip = NULL;
-			}
-			mark_auth_server_bad(auth_server);
-			return _connect_auth_server(level);
-		}
-		else {
-			/*
-			 * No
-			 *
-			 * It's probably safe to assume that the internet connection is malfunctioning
-			 * and nothing we can do will make it work
-			 */
-			mark_offline();
-			debug(LOG_DEBUG, "Level %d: Failed to resolve auth server and all popular servers. "
-					"The internet connection is probably down", level);
-			return(-1);
-		}
-	}
-	else {
-		/*
-		 * DNS resolving was successful
-		 */
-		ip = safe_strdup(inet_ntoa(*h_addr));
-		debug(LOG_DEBUG, "Level %d: Resolving auth server [%s] succeeded = [%s]", level, hostname, ip);
+        /* 
+         * If we got any h_addr buffer for one of the popular servers, in other
+         * words, if one of the popular servers resolved, we'll assume the DNS
+         * works, otherwise we'll deal with net connection or DNS failure.
+         */
+        if (h_addr) {
+            free(h_addr);
+            /*
+             * Yes
+             *
+             * The auth server's DNS server is probably dead. Try the next auth server
+             */
+            debug(LOG_DEBUG, "Level %d: Marking auth server [%s] as bad and trying next if possible", level, hostname);
+            if (auth_server->last_ip) {
+                free(auth_server->last_ip);
+                auth_server->last_ip = NULL;
+            }
+            mark_auth_server_bad(auth_server);
+            return _connect_auth_server(level);
+        } else {
+            /*
+             * No
+             *
+             * It's probably safe to assume that the internet connection is malfunctioning
+             * and nothing we can do will make it work
+             */
+            mark_offline();
+            debug(LOG_DEBUG, "Level %d: Failed to resolve auth server and all popular servers. "
+                  "The internet connection is probably down", level);
+            return (-1);
+        }
+    } else {
+        /*
+         * DNS resolving was successful
+         */
+        ip = safe_strdup(inet_ntoa(*h_addr));
+        debug(LOG_DEBUG, "Level %d: Resolving auth server [%s] succeeded = [%s]", level, hostname, ip);
 
-		if (!auth_server->last_ip || strcmp(auth_server->last_ip, ip) != 0) {
-			/*
-			 * But the IP address is different from the last one we knew
-			 * Update it
-			 */
-			debug(LOG_DEBUG, "Level %d: Updating last_ip IP of server [%s] to [%s]", level, hostname, ip);
-			if (auth_server->last_ip)
-				free(auth_server->last_ip);
-			auth_server->last_ip = ip;
+        if (!auth_server->last_ip || strcmp(auth_server->last_ip, ip) != 0) {
+            /*
+             * But the IP address is different from the last one we knew
+             * Update it
+             */
+            debug(LOG_DEBUG, "Level %d: Updating last_ip IP of server [%s] to [%s]", level, hostname, ip);
+            if (auth_server->last_ip)
+                free(auth_server->last_ip);
+            auth_server->last_ip = ip;
 
-			/* Update firewall rules */
-			fw_clear_authservers();
-			fw_set_authservers();
-		}
-		else {
-			/*
-			 * IP is the same as last time
-			 */
-			free(ip);
-		}
+            /* Update firewall rules */
+            fw_clear_authservers();
+            fw_set_authservers();
+        } else {
+            /*
+             * IP is the same as last time
+             */
+            free(ip);
+        }
 
-		/*
-		 * Connect to it
-		 */
-		int port = 0;
-		#ifdef USE_CYASSL
-		if (auth_server->authserv_use_ssl) {
-			debug(LOG_DEBUG, "Level %d: Connecting to SSL auth server %s:%d", level, hostname, auth_server->authserv_ssl_port);
-			port = htons(auth_server->authserv_ssl_port);
-		} else {
-			debug(LOG_DEBUG, "Level %d: Connecting to auth server %s:%d", level, hostname, auth_server->authserv_http_port);
-			port = htons(auth_server->authserv_http_port);
-		}
-		#endif
-		#ifndef USE_CYASSL
-		debug(LOG_DEBUG, "Level %d: Connecting to auth server %s:%d", level, hostname, auth_server->authserv_http_port);
-		port = htons(auth_server->authserv_http_port);
-		#endif
-		their_addr.sin_port = port;
-		their_addr.sin_family = AF_INET;
-		their_addr.sin_addr = *h_addr;
-		memset(&(their_addr.sin_zero), '\0', sizeof(their_addr.sin_zero));
-		free (h_addr);
+        /*
+         * Connect to it
+         */
+        int port = 0;
+#ifdef USE_CYASSL
+        if (auth_server->authserv_use_ssl) {
+            debug(LOG_DEBUG, "Level %d: Connecting to SSL auth server %s:%d", level, hostname,
+                  auth_server->authserv_ssl_port);
+            port = htons(auth_server->authserv_ssl_port);
+        } else {
+            debug(LOG_DEBUG, "Level %d: Connecting to auth server %s:%d", level, hostname,
+                  auth_server->authserv_http_port);
+            port = htons(auth_server->authserv_http_port);
+        }
+#endif
+#ifndef USE_CYASSL
+        debug(LOG_DEBUG, "Level %d: Connecting to auth server %s:%d", level, hostname, auth_server->authserv_http_port);
+        port = htons(auth_server->authserv_http_port);
+#endif
+        their_addr.sin_port = port;
+        their_addr.sin_family = AF_INET;
+        their_addr.sin_addr = *h_addr;
+        memset(&(their_addr.sin_zero), '\0', sizeof(their_addr.sin_zero));
+        free(h_addr);
 
-		if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-			debug(LOG_ERR, "Level %d: Failed to create a new SOCK_STREAM socket: %s", strerror(errno));
-			return(-1);
-		}
+        if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+            debug(LOG_ERR, "Level %d: Failed to create a new SOCK_STREAM socket: %s", strerror(errno));
+            return (-1);
+        }
 
-		if (connect(sockfd, (struct sockaddr *)&their_addr, sizeof(struct sockaddr)) == -1) {
-			/*
-			 * Failed to connect
-			 * Mark the server as bad and try the next one
-			 */
-			debug(LOG_DEBUG, "Level %d: Failed to connect to auth server %s:%d (%s). Marking it as bad and trying next if possible",
-                    level, hostname, ntohs(port), strerror(errno));
-			close(sockfd);
-			mark_auth_server_bad(auth_server);
-			return _connect_auth_server(level); /* Yay recursion! */
-		}
-		else {
-			/*
-			 * We have successfully connected
-			 */
-			debug(LOG_DEBUG, "Level %d: Successfully connected to auth server %s:%d", level, hostname, ntohs(port));
-			return sockfd;
-		}
-	}
+        if (connect(sockfd, (struct sockaddr *)&their_addr, sizeof(struct sockaddr)) == -1) {
+            /*
+             * Failed to connect
+             * Mark the server as bad and try the next one
+             */
+            debug(LOG_DEBUG,
+                  "Level %d: Failed to connect to auth server %s:%d (%s). Marking it as bad and trying next if possible",
+                  level, hostname, ntohs(port), strerror(errno));
+            close(sockfd);
+            mark_auth_server_bad(auth_server);
+            return _connect_auth_server(level); /* Yay recursion! */
+        } else {
+            /*
+             * We have successfully connected
+             */
+            debug(LOG_DEBUG, "Level %d: Successfully connected to auth server %s:%d", level, hostname, ntohs(port));
+            return sockfd;
+        }
+    }
 }

--- a/src/centralserver.c
+++ b/src/centralserver.c
@@ -105,7 +105,7 @@ auth_server_request(t_authresponse *authresponse, const char *request_type, cons
 
 	free(safe_token);
 
-	int res = 0;
+	char *res;
 	#ifdef USE_CYASSL
 	if (auth_server->authserv_use_ssl) {
 		res = https_get(sockfd, buf, auth_server->authserv_hostname);
@@ -116,22 +116,23 @@ auth_server_request(t_authresponse *authresponse, const char *request_type, cons
 	#ifndef USE_CYASSL
 	res = http_get(sockfd, buf);
 	#endif
-	if (res < 0) {
+	if (NULL == res) {
 		debug(LOG_ERR, "There was a problem talking to the auth server!");
 		return (AUTH_ERROR);
 	}
-
 	
-	if ((tmp = strstr(buf, "Auth: "))) {
+	if ((tmp = strstr(res, "Auth: "))) {
 		if (sscanf(tmp, "Auth: %d", (int *)&authresponse->authcode) == 1) {
 			debug(LOG_INFO, "Auth server returned authentication code %d", authresponse->authcode);
+            free(res);
 			return(authresponse->authcode);
 		} else {
 			debug(LOG_WARNING, "Auth server did not return expected authentication code");
+            free(res);
 			return(AUTH_ERROR);
 		}
 	}
-
+    free(res);
 	return(AUTH_ERROR);
 }
 

--- a/src/centralserver.h
+++ b/src/centralserver.h
@@ -1,3 +1,4 @@
+/* vim: set sw=4 ts=4 sts=4 et : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -46,13 +47,11 @@
 #define GATEWAY_MESSAGE_ACCOUNT_LOGGED_OUT     "logged-out"
 
 /** @brief Initiates a transaction with the auth server */
-t_authcode auth_server_request(t_authresponse *authresponse,
-			const char *request_type,
-			const char *ip,
-			const char *mac,
-			const char *token,
-			unsigned long long int incoming,
-			unsigned long long int outgoing);
+t_authcode auth_server_request(t_authresponse * authresponse,
+                               const char *request_type,
+                               const char *ip,
+                               const char *mac,
+                               const char *token, unsigned long long int incoming, unsigned long long int outgoing);
 
 /** @brief Tries really hard to connect to an auth server.  Returns a connected file descriptor or -1 on error */
 int connect_auth_server(void);
@@ -60,4 +59,4 @@ int connect_auth_server(void);
 /** @brief Helper function called by connect_auth_server() to do the actual work including recursion - DO NOT CALL DIRECTLY */
 int _connect_auth_server(int level);
 
-#endif /* _CENTRALSERVER_H_ */
+#endif                          /* _CENTRALSERVER_H_ */

--- a/src/ping_thread.c
+++ b/src/ping_thread.c
@@ -1,3 +1,4 @@
+/* vim: set sw=4 ts=4 sts=4 et : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -62,32 +63,32 @@ extern time_t started_time;
 /** Launches a thread that periodically checks in with the wifidog auth server to perform heartbeat function.
 @param arg NULL
 @todo This thread loops infinitely, need a watchdog to verify that it is still running?
-*/  
+*/
 void
 thread_ping(void *arg)
 {
-	pthread_cond_t		cond = PTHREAD_COND_INITIALIZER;
-	pthread_mutex_t		cond_mutex = PTHREAD_MUTEX_INITIALIZER;
-	struct	timespec	timeout;
-	
-	while (1) {
-		/* Make sure we check the servers at the very begining */
-		debug(LOG_DEBUG, "Running ping()");
-		ping();
-		
-		/* Sleep for config.checkinterval seconds... */
-		timeout.tv_sec = time(NULL) + config_get_config()->checkinterval;
-		timeout.tv_nsec = 0;
+    pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+    pthread_mutex_t cond_mutex = PTHREAD_MUTEX_INITIALIZER;
+    struct timespec timeout;
 
-		/* Mutex must be locked for pthread_cond_timedwait... */
-		pthread_mutex_lock(&cond_mutex);
-		
-		/* Thread safe "sleep" */
-		pthread_cond_timedwait(&cond, &cond_mutex, &timeout);
+    while (1) {
+        /* Make sure we check the servers at the very begining */
+        debug(LOG_DEBUG, "Running ping()");
+        ping();
 
-		/* No longer needs to be locked */
-		pthread_mutex_unlock(&cond_mutex);
-	}
+        /* Sleep for config.checkinterval seconds... */
+        timeout.tv_sec = time(NULL) + config_get_config()->checkinterval;
+        timeout.tv_nsec = 0;
+
+        /* Mutex must be locked for pthread_cond_timedwait... */
+        pthread_mutex_lock(&cond_mutex);
+
+        /* Thread safe "sleep" */
+        pthread_cond_timedwait(&cond, &cond_mutex, &timeout);
+
+        /* No longer needs to be locked */
+        pthread_mutex_unlock(&cond_mutex);
+    }
 }
 
 /** @internal
@@ -96,114 +97,112 @@ thread_ping(void *arg)
 static void
 ping(void)
 {
-	char			request[MAX_BUF];
-	FILE * fh;
-	int sockfd;
-	unsigned long int sys_uptime  = 0;
-	unsigned int      sys_memfree = 0;
-	float             sys_load    = 0;
-	t_auth_serv	*auth_server = NULL;
-	auth_server = get_auth_server();
+    char request[MAX_BUF];
+    FILE *fh;
+    int sockfd;
+    unsigned long int sys_uptime = 0;
+    unsigned int sys_memfree = 0;
+    float sys_load = 0;
+    t_auth_serv *auth_server = NULL;
+    auth_server = get_auth_server();
     static int authdown = 0;
-	
-	debug(LOG_DEBUG, "Entering ping()");
-	memset(request, 0, sizeof(request));
-	
-	/*
-	 * The ping thread does not really try to see if the auth server is actually
-	 * working. Merely that there is a web server listening at the port. And that
-	 * is done by connect_auth_server() internally.
-	 */
-	sockfd = connect_auth_server();
-	if (sockfd == -1) {
-		/*
-		 * No auth servers for me to talk to
-		 */
-		if (!authdown) {
-			fw_set_authdown();
-			authdown = 1;
-		}
-		return;
-	}
 
-	/*
-	 * Populate uptime, memfree and load
-	 */
-	if ((fh = fopen("/proc/uptime", "r"))) {
-		if(fscanf(fh, "%lu", &sys_uptime) != 1)
-			debug(LOG_CRIT, "Failed to read uptime");
+    debug(LOG_DEBUG, "Entering ping()");
+    memset(request, 0, sizeof(request));
 
-		fclose(fh);
-	}
-	if ((fh = fopen("/proc/meminfo", "r"))) {
-		while (!feof(fh)) {
-			if (fscanf(fh, "MemFree: %u", &sys_memfree) == 0) {
-				/* Not on this line */
-				while (!feof(fh) && fgetc(fh) != '\n');
-			}
-			else {
-				/* Found it */
-				break;
-			}
-		}
-		fclose(fh);
-	}
-	if ((fh = fopen("/proc/loadavg", "r"))) {
-		if(fscanf(fh, "%f", &sys_load) != 1)
-			debug(LOG_CRIT, "Failed to read loadavg");
+    /*
+     * The ping thread does not really try to see if the auth server is actually
+     * working. Merely that there is a web server listening at the port. And that
+     * is done by connect_auth_server() internally.
+     */
+    sockfd = connect_auth_server();
+    if (sockfd == -1) {
+        /*
+         * No auth servers for me to talk to
+         */
+        if (!authdown) {
+            fw_set_authdown();
+            authdown = 1;
+        }
+        return;
+    }
 
-		fclose(fh);
-	}
+    /*
+     * Populate uptime, memfree and load
+     */
+    if ((fh = fopen("/proc/uptime", "r"))) {
+        if (fscanf(fh, "%lu", &sys_uptime) != 1)
+            debug(LOG_CRIT, "Failed to read uptime");
 
-	/*
-	 * Prep & send request
-	 */
-	snprintf(request, sizeof(request) - 1,
-			"GET %s%sgw_id=%s&sys_uptime=%lu&sys_memfree=%u&sys_load=%.2f&wifidog_uptime=%lu HTTP/1.0\r\n"
-			"User-Agent: WiFiDog %s\r\n"
-			"Host: %s\r\n"
-			"\r\n",
-			auth_server->authserv_path,
-			auth_server->authserv_ping_script_path_fragment,
-			config_get_config()->gw_id,
-			sys_uptime,
-			sys_memfree,
-			sys_load,
-			(long unsigned int)((long unsigned int)time(NULL) - (long unsigned int)started_time),
-			VERSION,
-			auth_server->authserv_hostname);
+        fclose(fh);
+    }
+    if ((fh = fopen("/proc/meminfo", "r"))) {
+        while (!feof(fh)) {
+            if (fscanf(fh, "MemFree: %u", &sys_memfree) == 0) {
+                /* Not on this line */
+                while (!feof(fh) && fgetc(fh) != '\n') ;
+            } else {
+                /* Found it */
+                break;
+            }
+        }
+        fclose(fh);
+    }
+    if ((fh = fopen("/proc/loadavg", "r"))) {
+        if (fscanf(fh, "%f", &sys_load) != 1)
+            debug(LOG_CRIT, "Failed to read loadavg");
 
-	char *res;
-	#ifdef USE_CYASSL
-	if (auth_server->authserv_use_ssl) {
-		res = https_get(sockfd, request, auth_server->authserv_hostname);
-	} else {
-		res = http_get(sockfd, request);
-	}
-	#endif
-	#ifndef USE_CYASSL
-	res = http_get(sockfd, request);
-	#endif
-	if (NULL == res) {
-		debug(LOG_ERR, "There was a problem pinging the auth server!");
-  		if (!authdown) {
-			fw_set_authdown();
-			authdown = 1;
-		}
-	} else if (strstr(res, "Pong") == 0) {
-		debug(LOG_WARNING, "Auth server did NOT say Pong!");
-  		if (!authdown) {
-			fw_set_authdown();
-			authdown = 1;
-		}
+        fclose(fh);
+    }
+
+    /*
+     * Prep & send request
+     */
+    snprintf(request, sizeof(request) - 1,
+             "GET %s%sgw_id=%s&sys_uptime=%lu&sys_memfree=%u&sys_load=%.2f&wifidog_uptime=%lu HTTP/1.0\r\n"
+             "User-Agent: WiFiDog %s\r\n"
+             "Host: %s\r\n"
+             "\r\n",
+             auth_server->authserv_path,
+             auth_server->authserv_ping_script_path_fragment,
+             config_get_config()->gw_id,
+             sys_uptime,
+             sys_memfree,
+             sys_load,
+             (long unsigned int)((long unsigned int)time(NULL) - (long unsigned int)started_time),
+             VERSION, auth_server->authserv_hostname);
+
+    char *res;
+#ifdef USE_CYASSL
+    if (auth_server->authserv_use_ssl) {
+        res = https_get(sockfd, request, auth_server->authserv_hostname);
+    } else {
+        res = http_get(sockfd, request);
+    }
+#endif
+#ifndef USE_CYASSL
+    res = http_get(sockfd, request);
+#endif
+    if (NULL == res) {
+        debug(LOG_ERR, "There was a problem pinging the auth server!");
+        if (!authdown) {
+            fw_set_authdown();
+            authdown = 1;
+        }
+    } else if (strstr(res, "Pong") == 0) {
+        debug(LOG_WARNING, "Auth server did NOT say Pong!");
+        if (!authdown) {
+            fw_set_authdown();
+            authdown = 1;
+        }
         free(res);
-	} else {
-		debug(LOG_DEBUG, "Auth Server Says: Pong");
-  		if (authdown) {
-			fw_set_authup();
-			authdown = 0;
-		}
+    } else {
+        debug(LOG_DEBUG, "Auth Server Says: Pong");
+        if (authdown) {
+            fw_set_authup();
+            authdown = 0;
+        }
         free(res);
-	}
-	return;	
+    }
+    return;
 }

--- a/src/ping_thread.h
+++ b/src/ping_thread.h
@@ -1,3 +1,4 @@
+/* vim: set sw=4 ts=4 sts=4 et : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *

--- a/src/simple_http.h
+++ b/src/simple_http.h
@@ -26,6 +26,6 @@ char *http_get(const int, const char *);
 
 #ifdef USE_CYASSL
 char *https_get(const int, const char *, const char *);
-#endif /* defined(USE_CYASSL) */
+#endif                          /* defined(USE_CYASSL) */
 
-#endif /* defined(_SIMPLE_HTTP_H_) */
+#endif                          /* defined(_SIMPLE_HTTP_H_) */

--- a/src/simple_http.h
+++ b/src/simple_http.h
@@ -1,3 +1,4 @@
+/* vim: set sw=4 ts=4 sts=4 et : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -18,8 +19,13 @@
  *                                                                  *
  \********************************************************************/
 
-int http_get(const int, char*);
+#ifndef _SIMPLE_HTTP_H_
+#define _SIMPLE_HTTP_H_
+
+char *http_get(const int, const char *);
 
 #ifdef USE_CYASSL
-int https_get(const int, char*, const char*);
-#endif
+char *https_get(const int, const char *, const char *);
+#endif /* defined(USE_CYASSL) */
+
+#endif /* defined(_SIMPLE_HTTP_H_) */


### PR DESCRIPTION
Previous implementation "magically" knew caller's buffer size and made assumptions. New implementation, allocates as needed. `goto` usage is *not* an anti-pattern here. It's basically a C
form of `try { ..... } finally { ..... }`