### PR TITLE
Partial rewrite of fw_sync_with_auth

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -162,7 +162,7 @@ authenticate_client(request *r)
 	case AUTH_DENIED:
 		/* Central server said invalid token */
 		debug(LOG_INFO, "Got DENIED from central server authenticating token %s from %s at %s - deleting from firewall and redirecting them to denied message", client->token, client->ip, client->mac);
-		fw_deny(client->ip, client->mac, FW_MARK_KNOWN);
+		fw_deny(client, FW_MARK_KNOWN);
 		safe_asprintf(&urlFragment, "%smessage=%s",
 			auth_server->authserv_msg_script_path_fragment,
 			GATEWAY_MESSAGE_DENIED
@@ -176,8 +176,7 @@ authenticate_client(request *r)
 		debug(LOG_INFO, "Got VALIDATION from central server authenticating token %s from %s at %s"
 				"- adding to firewall and redirecting them to activate message", client->token,
 				client->ip, client->mac);
-		client->fw_connection_state = FW_MARK_PROBATION;
-		fw_allow(client->ip, client->mac, FW_MARK_PROBATION);
+		fw_allow(client, FW_MARK_PROBATION);
 		safe_asprintf(&urlFragment, "%smessage=%s",
 			auth_server->authserv_msg_script_path_fragment,
 			GATEWAY_MESSAGE_ACTIVATE_ACCOUNT
@@ -190,8 +189,7 @@ authenticate_client(request *r)
 		/* Logged in successfully as a regular account */
 		debug(LOG_INFO, "Got ALLOWED from central server authenticating token %s from %s at %s - "
 				"adding to firewall and redirecting them to portal", client->token, client->ip, client->mac);
-		client->fw_connection_state = FW_MARK_KNOWN;
-		fw_allow(client->ip, client->mac, FW_MARK_KNOWN);
+		fw_allow(client, FW_MARK_KNOWN);
         served_this_session++;
 		safe_asprintf(&urlFragment, "%sgw_id=%s",
 			auth_server->authserv_portal_script_path_fragment,

--- a/src/auth.c
+++ b/src/auth.c
@@ -162,7 +162,7 @@ authenticate_client(request *r)
 	case AUTH_DENIED:
 		/* Central server said invalid token */
 		debug(LOG_INFO, "Got DENIED from central server authenticating token %s from %s at %s - deleting from firewall and redirecting them to denied message", client->token, client->ip, client->mac);
-		fw_deny(client, FW_MARK_KNOWN);
+		fw_deny(client);
 		safe_asprintf(&urlFragment, "%smessage=%s",
 			auth_server->authserv_msg_script_path_fragment,
 			GATEWAY_MESSAGE_DENIED

--- a/src/auth.h
+++ b/src/auth.h
@@ -28,6 +28,7 @@
 #define _AUTH_H_
 
 #include "httpd.h"
+#include "client_list.h"
 
 /**
  * @brief Authentication codes returned by auth server.
@@ -51,6 +52,8 @@ typedef struct _t_authresponse {
     t_authcode authcode; /**< Authentication code returned by the server */
 } t_authresponse;
 
+/** @brief Logout a client and report to auth server. */
+void logout_client(t_client *);
 
 /** @brief Authenticate a single client against the central server */
 void authenticate_client(request *);

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -50,7 +50,7 @@ static t_client         *firstclient = NULL;
 /** @internal
  * Client ID
  */
-static volatile long long client_id = 1;
+static volatile unsigned long long client_id = 1;
 
 /**
  * Mutex to protect client_id and guarantee uniqueness.

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -44,8 +44,8 @@
 
 /** @internal
  * Holds a pointer to the first element of the list 
- */ 
-static t_client         *firstclient = NULL;
+ */
+static t_client *firstclient = NULL;
 
 /** @internal
  * Client ID
@@ -92,7 +92,7 @@ client_list_init(void)
  * @param Pointer to t_client object.
  */
 void
-client_list_insert_client(t_client *client)
+client_list_insert_client(t_client * client)
 {
     t_client *prev_head;
 
@@ -104,7 +104,6 @@ client_list_insert_client(t_client *client)
     firstclient = client;
 }
 
-
 /** Based on the parameters it receives, this function creates a new entry
  * in the connections list. All the memory allocation is done here.
  * Client is inserted at the head of the list.
@@ -113,23 +112,23 @@ client_list_insert_client(t_client *client)
  * @param token Token
  * @return Pointer to the client we just created
  */
-t_client         *
+t_client *
 client_list_add(const char *ip, const char *mac, const char *token)
 {
-    t_client         *curclient;
-    
+    t_client *curclient;
+
     curclient = client_get_new();
 
     curclient->ip = safe_strdup(ip);
     curclient->mac = safe_strdup(mac);
     curclient->token = safe_strdup(token);
-    curclient->counters.incoming = curclient->counters.incoming_history = curclient->counters.outgoing = curclient->counters.outgoing_history = 0;
+    curclient->counters.incoming = curclient->counters.incoming_history = curclient->counters.outgoing =
+        curclient->counters.outgoing_history = 0;
     curclient->counters.last_updated = time(NULL);
 
     client_list_insert_client(curclient);
 
-    debug(LOG_INFO, "Added a new client to linked list: IP: %s Token: %s",
-          ip, token);
+    debug(LOG_INFO, "Added a new client to linked list: IP: %s Token: %s", ip, token);
 
     return curclient;
 }
@@ -140,7 +139,7 @@ client_list_add(const char *ip, const char *mac, const char *token)
  * @return int Number of clients copied
  */
 int
-client_list_dup(t_client **dest)
+client_list_dup(t_client ** dest)
 {
     t_client *new, *cur, *top, *prev;
     int copied = 0;
@@ -149,7 +148,7 @@ client_list_dup(t_client **dest)
     new = top = prev = NULL;
 
     if (NULL == cur) {
-        *dest = new;  /* NULL */
+        *dest = new;            /* NULL */
         return copied;
     }
 
@@ -162,7 +161,7 @@ client_list_dup(t_client **dest)
             prev->next = new;
         }
         prev = new;
-        copied ++;
+        copied++;
         cur = cur->next;
     }
 
@@ -175,7 +174,7 @@ client_list_dup(t_client **dest)
  * @return duplicate client object with next == NULL
  */
 t_client *
-client_dup(const t_client *src)
+client_dup(const t_client * src)
 {
     t_client *new = client_get_new();
 
@@ -199,7 +198,7 @@ client_dup(const t_client *src)
  * @return pointer to the client in the list.
  */
 t_client *
-client_list_find_by_client(t_client *client)
+client_list_find_by_client(t_client * client)
 {
     t_client *c = firstclient;
 
@@ -218,10 +217,10 @@ client_list_find_by_client(t_client *client)
  * @param mac MAC we are looking for in the linked list
  * @return Pointer to the client, or NULL if not found
  */
-t_client         *
+t_client *
 client_list_find(const char *ip, const char *mac)
 {
-    t_client         *ptr;
+    t_client *ptr;
 
     ptr = firstclient;
     while (NULL != ptr) {
@@ -239,10 +238,10 @@ client_list_find(const char *ip, const char *mac)
  * @param ip IP we are looking for in the linked list
  * @return Pointer to the client, or NULL if not found
  */
-t_client         *
+t_client *
 client_list_find_by_ip(const char *ip)
 {
-    t_client         *ptr;
+    t_client *ptr;
 
     ptr = firstclient;
     while (NULL != ptr) {
@@ -260,10 +259,10 @@ client_list_find_by_ip(const char *ip)
  * @param mac Mac we are looking for in the linked list
  * @return Pointer to the client, or NULL if not found
  */
-t_client         *
+t_client *
 client_list_find_by_mac(const char *mac)
 {
-    t_client         *ptr;
+    t_client *ptr;
 
     ptr = firstclient;
     while (NULL != ptr) {
@@ -282,7 +281,7 @@ client_list_find_by_mac(const char *mac)
 t_client *
 client_list_find_by_token(const char *token)
 {
-    t_client         *ptr;
+    t_client *ptr;
 
     ptr = firstclient;
     while (NULL != ptr) {
@@ -299,7 +298,7 @@ client_list_find_by_token(const char *token)
  * @param list List to destroy (first item)
  */
 void
-client_list_destroy(t_client *list)
+client_list_destroy(t_client * list)
 {
     t_client *next;
 
@@ -354,7 +353,7 @@ client_list_delete(t_client * client)
 void
 client_list_remove(t_client * client)
 {
-    t_client         *ptr;
+    t_client *ptr;
 
     ptr = firstclient;
 

--- a/src/client_list.c
+++ b/src/client_list.c
@@ -261,6 +261,22 @@ client_list_find_by_token(const char *token)
     return NULL;
 }
 
+/** Destroy the client list. Including all free...
+ * DOES NOT UPDATE firstclient or anything else.
+ * @param list List to destroy (first item)
+ */
+void
+client_list_destroy(t_client *list)
+{
+    t_client *next;
+
+    while (NULL != list) {
+        next = list->next;
+        client_free_node(list);
+        list = next;
+    }
+}
+
 /** @internal
  * @brief Frees the memory used by a t_client structure
  * This function frees the memory used by the t_client structure in the

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -34,27 +34,27 @@ extern pthread_mutex_t client_list_mutex;
 /** Counters struct for a client's bandwidth usage (in bytes)
  */
 typedef struct _t_counters {
-    unsigned long long	incoming;	/**< @brief Incoming data total*/
-    unsigned long long	outgoing;	/**< @brief Outgoing data total*/
-    unsigned long long	incoming_history;	/**< @brief Incoming data before wifidog restarted*/
-    unsigned long long	outgoing_history;	/**< @brief Outgoing data before wifidog restarted*/
-    time_t	last_updated;	/**< @brief Last update of the counters */
+    unsigned long long incoming;        /**< @brief Incoming data total*/
+    unsigned long long outgoing;        /**< @brief Outgoing data total*/
+    unsigned long long incoming_history;        /**< @brief Incoming data before wifidog restarted*/
+    unsigned long long outgoing_history;        /**< @brief Outgoing data before wifidog restarted*/
+    time_t last_updated;        /**< @brief Last update of the counters */
 } t_counters;
 
 /** Client node for the connected client linked list.
  */
-typedef struct	_t_client {
-    struct	_t_client *next;        /**< @brief Pointer to the next client */
+typedef struct _t_client {
+    struct _t_client *next;             /**< @brief Pointer to the next client */
     unsigned long long id;           /**< @brief Unique ID per client */
-	char	*ip;			/**< @brief Client Ip address */
-	char	*mac;			/**< @brief Client Mac address */
-	char	*token;			/**< @brief Client token */
-	int fw_connection_state; /**< @brief Connection state in the
+    char *ip;                           /**< @brief Client Ip address */
+    char *mac;                          /**< @brief Client Mac address */
+    char *token;                        /**< @brief Client token */
+    int fw_connection_state;     /**< @brief Connection state in the
 						     firewall */
-	int	fd;			/**< @brief Client HTTP socket (valid only
+    int fd;                             /**< @brief Client HTTP socket (valid only
 					     during login before one of the
 					     _http_* function is called */
-	t_counters	counters;	/**< @brief Counters for input/output of
+    t_counters counters;                /**< @brief Counters for input/output of
 					     the client. */
 } t_client;
 
@@ -90,10 +90,10 @@ t_client *client_list_find_by_client(t_client *);
 
 /** @brief Finds a client only by its IP */
 t_client *client_list_find_by_ip(const char *); /* needed by fw_iptables.c, auth.c 
-					     * and wdctl_thread.c */
+                                                 * and wdctl_thread.c */
 
 /** @brief Finds a client only by its Mac */
-t_client *client_list_find_by_mac(const char *); /* needed by wdctl_thread.c */
+t_client *client_list_find_by_mac(const char *);        /* needed by wdctl_thread.c */
 
 /** @brief Finds a client by its token */
 t_client *client_list_find_by_token(const char *);
@@ -119,4 +119,4 @@ void client_free_node(t_client *);
 	debug(LOG_DEBUG, "Client list unlocked"); \
 } while (0)
 
-#endif /* _CLIENT_LIST_H_ */
+#endif                          /* _CLIENT_LIST_H_ */

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -44,7 +44,8 @@ typedef struct _t_counters {
 /** Client node for the connected client linked list.
  */
 typedef struct	_t_client {
-  struct	_t_client *next;        /**< @brief Pointer to the next client */
+    struct	_t_client *next;        /**< @brief Pointer to the next client */
+    long long id;           /**< @brief Unique ID per client */
 	char	*ip;			/**< @brief Client Ip address */
 	char	*mac;			/**< @brief Client Mac address */
 	char	*token;			/**< @brief Client token */
@@ -83,6 +84,9 @@ t_client *client_dup(const t_client *);
 
 /** @brief Finds a client by its IP and MAC */
 t_client *client_list_find(const char *, const char *);
+
+/** @brief Find a client in the list from a client struct, matching operates by id. */
+t_client *client_list_find_by_client(t_client *);
 
 /** @brief Finds a client only by its IP */
 t_client *client_list_find_by_ip(const char *); /* needed by fw_iptables.c, auth.c 

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -69,6 +69,9 @@ void client_list_init(void);
 /** @brief Insert client at head of list */
 void client_list_insert_client(t_client *);
 
+/** @brief Destroy the client list. Including all free... */
+void client_list_destroy(t_client *);
+
 /** @brief Adds a new client to the connections list */
 t_client *client_list_add(const char *, const char *, const char *);
 

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -45,7 +45,7 @@ typedef struct _t_counters {
  */
 typedef struct	_t_client {
     struct	_t_client *next;        /**< @brief Pointer to the next client */
-    long long id;           /**< @brief Unique ID per client */
+    unsigned long long id;           /**< @brief Unique ID per client */
 	char	*ip;			/**< @brief Client Ip address */
 	char	*mac;			/**< @brief Client Mac address */
 	char	*token;			/**< @brief Client token */

--- a/src/client_list.h
+++ b/src/client_list.h
@@ -67,32 +67,38 @@ t_client *client_get_first_client(void);
 void client_list_init(void);
 
 /** @brief Insert client at head of list */
-void client_list_insert_client(t_client *client);
+void client_list_insert_client(t_client *);
 
 /** @brief Adds a new client to the connections list */
-t_client *client_list_append(const char *ip, const char *mac, const char *token);
+t_client *client_list_add(const char *, const char *, const char *);
+
+/** Duplicate the whole client list to process in a thread safe way */
+int client_list_dup(t_client **);
+
+/** @brief Create a duplicate of a client. */
+t_client *client_dup(const t_client *);
 
 /** @brief Finds a client by its IP and MAC */
-t_client *client_list_find(const char *ip, const char *mac);
+t_client *client_list_find(const char *, const char *);
 
 /** @brief Finds a client only by its IP */
-t_client *client_list_find_by_ip(const char *ip); /* needed by fw_iptables.c, auth.c 
+t_client *client_list_find_by_ip(const char *); /* needed by fw_iptables.c, auth.c 
 					     * and wdctl_thread.c */
 
 /** @brief Finds a client only by its Mac */
-t_client *client_list_find_by_mac(const char *mac); /* needed by wdctl_thread.c */
+t_client *client_list_find_by_mac(const char *); /* needed by wdctl_thread.c */
 
 /** @brief Finds a client by its token */
-t_client *client_list_find_by_token(const char *token);
+t_client *client_list_find_by_token(const char *);
 
 /** @brief Deletes a client from the connections list and frees its memory*/
-void client_list_delete(t_client *client);
+void client_list_delete(t_client *);
 
 /** @brief Removes a client from the connections list */
-void client_list_remove(t_client *client);
+void client_list_remove(t_client *);
 
 /** @brief Free memory associated with a client */
-void client_free_node(t_client *client);
+void client_free_node(t_client *);
 
 #define LOCK_CLIENT_LIST() do { \
 	debug(LOG_DEBUG, "Locking client list"); \

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -64,6 +64,9 @@
 #include "client_list.h"
 #include "commandline.h"
 
+
+int icmp_fd;
+
 static int _fw_deny_raw(const char *, const char *, const int);
 
 /**
@@ -395,38 +398,9 @@ fw_sync_with_authserver(void)
 }
 
 /**
- * @brief Logout a client and report to auth server.
- *
- * This function assumes it is being called with the client lock held! This
- * function remove the client from the client list and free its memory, so
- * client is no langer valid when this method returns.
- *
- * @param client Points to the client to be logged out
+ * Ping an IP.
+ * @param IP/host as string, will be sent to gethostbyname
  */
-void
-logout_client(t_client *client)
-{
-    t_authresponse  authresponse;
-    const s_config *config = config_get_config();
-    fw_deny(client);
-    client_list_remove(client);
-
-    /* Advertise the logout if we have an auth server */
-    if (config->auth_servers != NULL) {
-        UNLOCK_CLIENT_LIST();
-        auth_server_request(&authresponse, REQUEST_TYPE_LOGOUT,
-            client->ip, client->mac, client->token,
-            client->counters.incoming,
-            client->counters.outgoing);
-
-        if (authresponse.authcode==AUTH_ERROR)
-            debug(LOG_WARNING, "Auth server error when reporting logout");
-        LOCK_CLIENT_LIST();
-    }
-
-    client_free_node(client);
-}
-
 void
 icmp_ping(const char *host)
 {

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -44,17 +44,12 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <sys/uio.h>
-#include <fcntl.h>
 #include <netdb.h>
 #include <sys/time.h>
 
-#include <net/ethernet.h>
-#include <netinet/ip.h>
-#include <netinet/ip_icmp.h>
-#include <netpacket/packet.h>
-
 #include "httpd.h"
 #include "safe.h"
+#include "util.h"
 #include "debug.h"
 #include "conf.h"
 #include "firewall.h"
@@ -64,8 +59,6 @@
 #include "client_list.h"
 #include "commandline.h"
 
-
-int icmp_fd;
 
 static int _fw_deny_raw(const char *, const char *, const int);
 
@@ -202,18 +195,11 @@ arp_get(const char *req_ip)
 int
 fw_init(void)
 {
-    int flags, oneopt = 1, zeroopt = 0;
 	int result = 0;
     int new_fw_state;
 	t_client * client = NULL;
 
-    debug(LOG_INFO, "Creating ICMP socket");
-    if ((icmp_fd = socket (AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1 ||
-            (flags = fcntl(icmp_fd, F_GETFL, 0)) == -1 ||
-             fcntl(icmp_fd, F_SETFL, flags | O_NONBLOCK) == -1 ||
-             setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &oneopt, sizeof(oneopt)) ||
-             setsockopt(icmp_fd, SOL_SOCKET, SO_DONTROUTE, &zeroopt, sizeof(zeroopt)) == -1) {
-        debug(LOG_ERR, "Cannot create ICMP raw socket.");
+    if (!init_icmp_socket()) {
         return 0;
     }
 
@@ -261,11 +247,7 @@ fw_set_authservers(void)
 int
 fw_destroy(void)
 {
-    if (icmp_fd != 0) {
-        debug(LOG_INFO, "Closing ICMP socket");
-        close(icmp_fd);
-    }
-
+    close_icmp_socket();
     debug(LOG_INFO, "Removing Firewall rules");
     return iptables_fw_destroy();
 }
@@ -397,74 +379,3 @@ fw_sync_with_authserver(void)
     client_list_destroy(worklist);
 }
 
-/**
- * Ping an IP.
- * @param IP/host as string, will be sent to gethostbyname
- */
-void
-icmp_ping(const char *host)
-{
-	struct sockaddr_in saddr;
-	struct {
-		struct ip ip;
-		struct icmp icmp;
-	} packet;
-	unsigned int i, j;
-	int opt = 2000;
-	unsigned short id = rand16();
-
-	memset(&saddr, 0, sizeof(saddr));
-	saddr.sin_family = AF_INET;
-	inet_aton(host, &saddr.sin_addr);
-#if defined(HAVE_SOCKADDR_SA_LEN)
-	saddr.sin_len = sizeof(struct sockaddr_in);
-#endif
-
-	memset(&packet.icmp, 0, sizeof(packet.icmp));
-	packet.icmp.icmp_type = ICMP_ECHO;
-	packet.icmp.icmp_id = id;
-
-	for (j = 0, i = 0; i < sizeof(struct icmp) / 2; i++)
-		j += ((unsigned short *)&packet.icmp)[i];
-
-	while (j >> 16)
-		j = (j & 0xffff) + (j >> 16);
-
-	packet.icmp.icmp_cksum = (j == 0xffff) ? j : ~j;
-
-	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
-		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
-
-	if (sendto(icmp_fd, (char *)&packet.icmp, sizeof(struct icmp), 0,
-	           (const struct sockaddr *)&saddr, sizeof(saddr)) == -1)
-		debug(LOG_ERR, "sendto(): %s", strerror(errno));
-
-	opt = 1;
-	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
-		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
-
-	return;
-}
-
-unsigned short rand16(void) {
-  static int been_seeded = 0;
-
-  if (!been_seeded) {
-    unsigned int seed = 0;
-    struct timeval now;
-
-    /* not a very good seed but what the heck, it needs to be quickly acquired */
-    gettimeofday(&now, NULL);
-    seed = now.tv_sec ^ now.tv_usec ^ (getpid() << 16);
-
-    srand(seed);
-    been_seeded = 1;
-    }
-
-    /* Some rand() implementations have less randomness in low bits
-     * than in high bits, so we only pay attention to the high ones.
-     * But most implementations don't touch the high bit, so we
-     * ignore that one.
-     **/
-      return( (unsigned short) (rand() >> 15) );
-}

--- a/src/firewall.c
+++ b/src/firewall.c
@@ -280,7 +280,7 @@ fw_sync_with_authserver(void)
             debug(LOG_INFO, "%s - Inactive for more than %ld seconds, removing client and denying in firewall",
                     p1->ip, config->checkinterval * config->clienttimeout);
             LOCK_CLIENT_LIST();
-            tmp = client_list_find(p1->ip, p1->mac);
+            tmp = client_list_find_by_client(p1);
             if (NULL != tmp) {
                 logout_client(tmp);
             } else {
@@ -298,7 +298,7 @@ fw_sync_with_authserver(void)
              * configured!
              */
             LOCK_CLIENT_LIST();
-            tmp = client_list_find(p1->ip, p1->mac);
+            tmp = client_list_find_by_client(p1);
             if (NULL == tmp) {
                 UNLOCK_CLIENT_LIST();
                 debug(LOG_NOTICE, "Client was already removed. Skipping auth processing");

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -34,7 +34,7 @@ typedef enum _t_fw_marks {
     FW_MARK_NONE = 0, /**< @brief No mark set. */
     FW_MARK_PROBATION = 1, /**< @brief The client is in probation period and must be authenticated 
 			    @todo: VERIFY THAT THIS IS ACCURATE*/
-    FW_MARK_KNOWN = 2,  /**< @brief The client is known to the firewall */ 
+    FW_MARK_KNOWN = 2,  /**< @brief The client is known to the firewall */
     FW_MARK_AUTH_IS_DOWN = 253, /**< @brief The auth servers are down */
     FW_MARK_LOCKED = 254 /**< @brief The client has been locked out */
 } t_fw_marks;
@@ -72,4 +72,4 @@ void fw_sync_with_authserver(void);
 /** @brief Get an IP's MAC address from the ARP cache.*/
 char *arp_get(const char *);
 
-#endif /* _FIREWALL_H_ */
+#endif                          /* _FIREWALL_H_ */

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -61,7 +61,7 @@ int fw_allow(t_client *, int);
 int fw_allow_host(const char *);
 
 /** @brief Deny a client access through the firewall*/
-int fw_deny(t_client *, int);
+int fw_deny(t_client *);
 
 /** @brief Passthrough for clients when auth server is down */
 int fw_set_authdown(void);

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -29,8 +29,6 @@
 
 #include "client_list.h"
 
-extern int icmp_fd;
-
 /** Used by fw_iptables.c */
 typedef enum _t_fw_marks {
     FW_MARK_NONE = 0, /**< @brief No mark set. */
@@ -73,11 +71,5 @@ void fw_sync_with_authserver(void);
 
 /** @brief Get an IP's MAC address from the ARP cache.*/
 char *arp_get(const char *);
-
-/** @brief ICMP Ping an IP */
-void icmp_ping(const char *);
-
-/** @brief cheap random */
-unsigned short rand16(void);
 
 #endif /* _FIREWALL_H_ */

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -1,3 +1,4 @@
+/* vim: set et sw=4 ts=4 sts=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -30,7 +30,6 @@
 #include "client_list.h"
 
 extern int icmp_fd;
-int icmp_fd;
 
 /** Used by fw_iptables.c */
 typedef enum _t_fw_marks {
@@ -80,8 +79,5 @@ void icmp_ping(const char *);
 
 /** @brief cheap random */
 unsigned short rand16(void);
-
-/** @brief Logout a client and report to auth server. */
-void logout_client(t_client *);
 
 #endif /* _FIREWALL_H_ */

--- a/src/firewall.h
+++ b/src/firewall.h
@@ -34,6 +34,7 @@ int icmp_fd;
 
 /** Used by fw_iptables.c */
 typedef enum _t_fw_marks {
+    FW_MARK_NONE = 0, /**< @brief No mark set. */
     FW_MARK_PROBATION = 1, /**< @brief The client is in probation period and must be authenticated 
 			    @todo: VERIFY THAT THIS IS ACCURATE*/
     FW_MARK_KNOWN = 2,  /**< @brief The client is known to the firewall */ 
@@ -54,13 +55,13 @@ void fw_set_authservers(void);
 int fw_destroy(void);
 
 /** @brief Allow a user through the firewall*/
-int fw_allow(const char *ip, const char *mac, int profile);
+int fw_allow(t_client *, int);
 
 /** @brief Allow a host through the firewall*/
-int fw_allow_host(const char *host);
+int fw_allow_host(const char *);
 
 /** @brief Deny a client access through the firewall*/
-int fw_deny(const char *ip, const char *mac, int profile);
+int fw_deny(t_client *, int);
 
 /** @brief Passthrough for clients when auth server is down */
 int fw_set_authdown(void);
@@ -72,15 +73,15 @@ int fw_set_authup(void);
 void fw_sync_with_authserver(void);
 
 /** @brief Get an IP's MAC address from the ARP cache.*/
-char *arp_get(const char *req_ip);
+char *arp_get(const char *);
 
 /** @brief ICMP Ping an IP */
-void icmp_ping(const char *host);
+void icmp_ping(const char *);
 
 /** @brief cheap random */
 unsigned short rand16(void);
 
 /** @brief Logout a client and report to auth server. */
-void logout_client(t_client *client);
+void logout_client(t_client *);
 
 #endif /* _FIREWALL_H_ */

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -1,3 +1,4 @@
+/* vim: set et ts=4 sts=4 sw=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *

--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -53,7 +53,7 @@ static char *iptables_compile(const char *, const char *, const t_firewall_rule 
 static void iptables_load_ruleset(const char *, const char *, const char *);
 
 /**
-Used to supress the error output of the firewall during destruction */ 
+Used to supress the error output of the firewall during destruction */
 static int fw_quiet = 0;
 
 /** @internal
@@ -67,23 +67,22 @@ static int fw_quiet = 0;
 static void
 iptables_insert_gateway_id(char **input)
 {
-	char *token;
-	const s_config *config;
-	char *buffer;
+    char *token;
+    const s_config *config;
+    char *buffer;
 
-	if (strstr(*input, "$ID$")==NULL)
-		return;
+    if (strstr(*input, "$ID$") == NULL)
+        return;
 
+    while ((token = strstr(*input, "$ID$")) != NULL)
+        /* This string may look odd but it's standard POSIX and ISO C */
+        memcpy(token, "%1$s", 4);
 
-	while ((token=strstr(*input, "$ID$"))!=NULL)
-		/* This string may look odd but it's standard POSIX and ISO C */
-		memcpy(token, "%1$s", 4);
+    config = config_get_config();
+    safe_asprintf(&buffer, *input, config->gw_interface);
 
-	config = config_get_config();
-	safe_asprintf(&buffer, *input, config->gw_interface);
-
-	free(*input);
-	*input=buffer;
+    free(*input);
+    *input = buffer;
 }
 
 /** @internal 
@@ -91,35 +90,35 @@ iptables_insert_gateway_id(char **input)
 static int
 iptables_do_command(const char *format, ...)
 {
-	va_list vlist;
-	char *fmt_cmd;
-	char *cmd;
-	int rc;
+    va_list vlist;
+    char *fmt_cmd;
+    char *cmd;
+    int rc;
 
-	va_start(vlist, format);
-	safe_vasprintf(&fmt_cmd, format, vlist);
-	va_end(vlist);
+    va_start(vlist, format);
+    safe_vasprintf(&fmt_cmd, format, vlist);
+    va_end(vlist);
 
-	safe_asprintf(&cmd, "iptables %s", fmt_cmd);
-	free(fmt_cmd);
+    safe_asprintf(&cmd, "iptables %s", fmt_cmd);
+    free(fmt_cmd);
 
-	iptables_insert_gateway_id(&cmd);
+    iptables_insert_gateway_id(&cmd);
 
-	debug(LOG_DEBUG, "Executing command: %s", cmd);
+    debug(LOG_DEBUG, "Executing command: %s", cmd);
 
-	rc = execute(cmd, fw_quiet);
+    rc = execute(cmd, fw_quiet);
 
-	if (rc!=0) {
-		// If quiet, do not display the error
-		if (fw_quiet == 0)
-			debug(LOG_ERR, "iptables command failed(%d): %s", rc, cmd);
-		else if (fw_quiet == 1)
-			debug(LOG_DEBUG, "iptables command failed(%d): %s", rc, cmd);
-	}
+    if (rc != 0) {
+        // If quiet, do not display the error
+        if (fw_quiet == 0)
+            debug(LOG_ERR, "iptables command failed(%d): %s", rc, cmd);
+        else if (fw_quiet == 1)
+            debug(LOG_DEBUG, "iptables command failed(%d): %s", rc, cmd);
+    }
 
-	free(cmd);
+    free(cmd);
 
-	return rc;
+    return rc;
 }
 
 /**
@@ -130,67 +129,62 @@ iptables_do_command(const char *format, ...)
  * @arg chain Chain that the command will be (-A)ppended to.
  * @arg rule Definition of a rule into a struct, from conf.c.
  */
-	static char *
-iptables_compile(const char * table, const char *chain, const t_firewall_rule *rule)
+static char *
+iptables_compile(const char *table, const char *chain, const t_firewall_rule * rule)
 {
-	char	command[MAX_BUF],
-		*mode;
+    char command[MAX_BUF], *mode;
 
-	memset(command, 0, MAX_BUF);
-	mode = NULL;
+    memset(command, 0, MAX_BUF);
+    mode = NULL;
 
-	switch (rule->target){
-	case TARGET_DROP:
-		if (strncmp(table, "nat", 3) == 0) {
-			free(mode);
-			return NULL;
-		}
-		mode = safe_strdup("DROP");
-		break;
-	case TARGET_REJECT:
-		if (strncmp(table, "nat", 3) == 0) {
-			free(mode);
-			return NULL;
-		}
-		mode = safe_strdup("REJECT");
-		break;
-	case TARGET_ACCEPT:
-		mode = safe_strdup("ACCEPT");
-		break;
-	case TARGET_LOG:
-		mode = safe_strdup("LOG");
-		break;
-	case TARGET_ULOG:
-		mode = safe_strdup("ULOG");
-		break;
-	}
-        
-	snprintf(command, sizeof(command),  "-t %s -A %s ",table, chain);
-	if (rule->mask != NULL) {
-		if (rule->mask_is_ipset) {
-			snprintf((command + strlen(command)), (sizeof(command) -
-					strlen(command)), "-m set --match-set %s dst ", rule->mask);
-		} else {
-			snprintf((command + strlen(command)), (sizeof(command) -
-					strlen(command)), "-d %s ", rule->mask);
-		}
-	}
-	if (rule->protocol != NULL) {
-		snprintf((command + strlen(command)), (sizeof(command) -
-					strlen(command)), "-p %s ", rule->protocol);
-	}
-	if (rule->port != NULL) {
-		snprintf((command + strlen(command)), (sizeof(command) -
-					strlen(command)), "--dport %s ", rule->port);
-	}
-	snprintf((command + strlen(command)), (sizeof(command) - 
-				strlen(command)), "-j %s", mode);
+    switch (rule->target) {
+    case TARGET_DROP:
+        if (strncmp(table, "nat", 3) == 0) {
+            free(mode);
+            return NULL;
+        }
+        mode = safe_strdup("DROP");
+        break;
+    case TARGET_REJECT:
+        if (strncmp(table, "nat", 3) == 0) {
+            free(mode);
+            return NULL;
+        }
+        mode = safe_strdup("REJECT");
+        break;
+    case TARGET_ACCEPT:
+        mode = safe_strdup("ACCEPT");
+        break;
+    case TARGET_LOG:
+        mode = safe_strdup("LOG");
+        break;
+    case TARGET_ULOG:
+        mode = safe_strdup("ULOG");
+        break;
+    }
 
-	free(mode);
+    snprintf(command, sizeof(command), "-t %s -A %s ", table, chain);
+    if (rule->mask != NULL) {
+        if (rule->mask_is_ipset) {
+            snprintf((command + strlen(command)), (sizeof(command) -
+                                                   strlen(command)), "-m set --match-set %s dst ", rule->mask);
+        } else {
+            snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-d %s ", rule->mask);
+        }
+    }
+    if (rule->protocol != NULL) {
+        snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-p %s ", rule->protocol);
+    }
+    if (rule->port != NULL) {
+        snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "--dport %s ", rule->port);
+    }
+    snprintf((command + strlen(command)), (sizeof(command) - strlen(command)), "-j %s", mode);
 
-	/* XXX The buffer command, an automatic variable, will get cleaned
-	 * off of the stack when we return, so we strdup() it. */
-	return(safe_strdup(command));
+    free(mode);
+
+    /* XXX The buffer command, an automatic variable, will get cleaned
+     * off of the stack when we return, so we strdup() it. */
+    return (safe_strdup(command));
 }
 
 /**
@@ -200,294 +194,299 @@ iptables_compile(const char * table, const char *chain, const t_firewall_rule *r
  * @arg table Table containing the chain.
  * @arg chain IPTables chain the rules go into
  */
-	static void
-iptables_load_ruleset(const char * table, const char *ruleset, const char *chain)
+static void
+iptables_load_ruleset(const char *table, const char *ruleset, const char *chain)
 {
-	t_firewall_rule		*rule;
-	char			*cmd;
+    t_firewall_rule *rule;
+    char *cmd;
 
-	debug(LOG_DEBUG, "Load ruleset %s into table %s, chain %s", ruleset, table, chain);
+    debug(LOG_DEBUG, "Load ruleset %s into table %s, chain %s", ruleset, table, chain);
 
-	for (rule = get_ruleset(ruleset); rule != NULL; rule = rule->next) {
-		cmd = iptables_compile(table, chain, rule);
-		if (cmd!=NULL) {
-			debug(LOG_DEBUG, "Loading rule \"%s\" into table %s, chain %s", cmd, table, chain);
-			iptables_do_command(cmd);
-		}
-		free(cmd);
-	}
+    for (rule = get_ruleset(ruleset); rule != NULL; rule = rule->next) {
+        cmd = iptables_compile(table, chain, rule);
+        if (cmd != NULL) {
+            debug(LOG_DEBUG, "Loading rule \"%s\" into table %s, chain %s", cmd, table, chain);
+            iptables_do_command(cmd);
+        }
+        free(cmd);
+    }
 
-	debug(LOG_DEBUG, "Ruleset %s loaded into table %s, chain %s", ruleset, table, chain);
+    debug(LOG_DEBUG, "Ruleset %s loaded into table %s, chain %s", ruleset, table, chain);
 }
 
-	void
+void
 iptables_fw_clear_authservers(void)
 {
-	iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
 }
 
-	void
+void
 iptables_fw_set_authservers(void)
 {
-	const s_config *config;
-	t_auth_serv *auth_server;
+    const s_config *config;
+    t_auth_serv *auth_server;
 
-	config = config_get_config();
+    config = config_get_config();
 
-	for (auth_server = config->auth_servers; auth_server != NULL; auth_server = auth_server->next) {
-		if (auth_server->last_ip && strcmp(auth_server->last_ip, "0.0.0.0") != 0) {
-			iptables_do_command("-t filter -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
-			iptables_do_command("-t nat -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
-		}
-	}
+    for (auth_server = config->auth_servers; auth_server != NULL; auth_server = auth_server->next) {
+        if (auth_server->last_ip && strcmp(auth_server->last_ip, "0.0.0.0") != 0) {
+            iptables_do_command("-t filter -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
+            iptables_do_command("-t nat -A " CHAIN_AUTHSERVERS " -d %s -j ACCEPT", auth_server->last_ip);
+        }
+    }
 
 }
 
 /** Initialize the firewall rules
 */
-	int
+int
 iptables_fw_init(void)
 {
-	const s_config *config;
-	char * ext_interface = NULL;
-	int gw_port = 0;
-	t_trusted_mac *p;
-	int proxy_port;
-	fw_quiet = 0;
+    const s_config *config;
+    char *ext_interface = NULL;
+    int gw_port = 0;
+    t_trusted_mac *p;
+    int proxy_port;
+    fw_quiet = 0;
     int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
 
-	LOCK_CONFIG();
-	config = config_get_config();
-	gw_port = config->gw_port;
-	if (config->external_interface) {
-		ext_interface = safe_strdup(config->external_interface);
-	} else {
-		ext_interface = get_ext_iface();
-	}
+    LOCK_CONFIG();
+    config = config_get_config();
+    gw_port = config->gw_port;
+    if (config->external_interface) {
+        ext_interface = safe_strdup(config->external_interface);
+    } else {
+        ext_interface = get_ext_iface();
+    }
 
-	if (ext_interface == NULL) {
-		UNLOCK_CONFIG();
-		debug(LOG_ERR, "FATAL: no external interface");
-		return 0;
-	}
-	/*
-	 *
-	 * Everything in the MANGLE table
-	 *
-	 */
+    if (ext_interface == NULL) {
+        UNLOCK_CONFIG();
+        debug(LOG_ERR, "FATAL: no external interface");
+        return 0;
+    }
+    /*
+     *
+     * Everything in the MANGLE table
+     *
+     */
 
-	/* Create new chains */
-	iptables_do_command("-t mangle -N " CHAIN_TRUSTED);
-	iptables_do_command("-t mangle -N " CHAIN_OUTGOING);
-	iptables_do_command("-t mangle -N " CHAIN_INCOMING);
+    /* Create new chains */
+    iptables_do_command("-t mangle -N " CHAIN_TRUSTED);
+    iptables_do_command("-t mangle -N " CHAIN_OUTGOING);
+    iptables_do_command("-t mangle -N " CHAIN_INCOMING);
     if (got_authdown_ruleset)
         iptables_do_command("-t mangle -N " CHAIN_AUTH_IS_DOWN);
 
-	/* Assign links and rules to these new chains */
-	iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_OUTGOING, config->gw_interface);
-	iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TRUSTED, config->gw_interface); //this rule will be inserted before the prior one
+    /* Assign links and rules to these new chains */
+    iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_OUTGOING, config->gw_interface);
+    iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_TRUSTED, config->gw_interface);     //this rule will be inserted before the prior one
     if (got_authdown_ruleset)
-        iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_AUTH_IS_DOWN, config->gw_interface); //this rule must be last in the chain
-	iptables_do_command("-t mangle -I POSTROUTING 1 -o %s -j " CHAIN_INCOMING, config->gw_interface);
+        iptables_do_command("-t mangle -I PREROUTING 1 -i %s -j " CHAIN_AUTH_IS_DOWN, config->gw_interface);    //this rule must be last in the chain
+    iptables_do_command("-t mangle -I POSTROUTING 1 -o %s -j " CHAIN_INCOMING, config->gw_interface);
 
-	for (p = config->trustedmaclist; p != NULL; p = p->next)
-		iptables_do_command("-t mangle -A " CHAIN_TRUSTED " -m mac --mac-source %s -j MARK --set-mark %d", p->mac, FW_MARK_KNOWN);
+    for (p = config->trustedmaclist; p != NULL; p = p->next)
+        iptables_do_command("-t mangle -A " CHAIN_TRUSTED " -m mac --mac-source %s -j MARK --set-mark %d", p->mac,
+                            FW_MARK_KNOWN);
 
-	/*
-	 *
-	 * Everything in the NAT table
-	 *
-	 */
+    /*
+     *
+     * Everything in the NAT table
+     *
+     */
 
-	/* Create new chains */
-	iptables_do_command("-t nat -N " CHAIN_OUTGOING);
-	iptables_do_command("-t nat -N " CHAIN_TO_ROUTER);
-	iptables_do_command("-t nat -N " CHAIN_TO_INTERNET);
-	iptables_do_command("-t nat -N " CHAIN_GLOBAL);
-	iptables_do_command("-t nat -N " CHAIN_UNKNOWN);
-	iptables_do_command("-t nat -N " CHAIN_AUTHSERVERS);
+    /* Create new chains */
+    iptables_do_command("-t nat -N " CHAIN_OUTGOING);
+    iptables_do_command("-t nat -N " CHAIN_TO_ROUTER);
+    iptables_do_command("-t nat -N " CHAIN_TO_INTERNET);
+    iptables_do_command("-t nat -N " CHAIN_GLOBAL);
+    iptables_do_command("-t nat -N " CHAIN_UNKNOWN);
+    iptables_do_command("-t nat -N " CHAIN_AUTHSERVERS);
     if (got_authdown_ruleset)
         iptables_do_command("-t nat -N " CHAIN_AUTH_IS_DOWN);
 
-	/* Assign links and rules to these new chains */
-	iptables_do_command("-t nat -A PREROUTING -i %s -j " CHAIN_OUTGOING, config->gw_interface);
+    /* Assign links and rules to these new chains */
+    iptables_do_command("-t nat -A PREROUTING -i %s -j " CHAIN_OUTGOING, config->gw_interface);
 
-	iptables_do_command("-t nat -A " CHAIN_OUTGOING " -d %s -j " CHAIN_TO_ROUTER, config->gw_address);
-	iptables_do_command("-t nat -A " CHAIN_TO_ROUTER " -j ACCEPT");
+    iptables_do_command("-t nat -A " CHAIN_OUTGOING " -d %s -j " CHAIN_TO_ROUTER, config->gw_address);
+    iptables_do_command("-t nat -A " CHAIN_TO_ROUTER " -j ACCEPT");
 
-	iptables_do_command("-t nat -A " CHAIN_OUTGOING " -j " CHAIN_TO_INTERNET);
+    iptables_do_command("-t nat -A " CHAIN_OUTGOING " -j " CHAIN_TO_INTERNET);
 
-	if((proxy_port=config_get_config()->proxy_port) != 0){
-		debug(LOG_DEBUG,"Proxy port set, setting proxy rule");
-		iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_KNOWN, proxy_port);
-		iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_PROBATION, proxy_port);
-	}
+    if ((proxy_port = config_get_config()->proxy_port) != 0) {
+        debug(LOG_DEBUG, "Proxy port set, setting proxy rule");
+        iptables_do_command("-t nat -A " CHAIN_TO_INTERNET
+                            " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_KNOWN,
+                            proxy_port);
+        iptables_do_command("-t nat -A " CHAIN_TO_INTERNET
+                            " -p tcp --dport 80 -m mark --mark 0x%u -j REDIRECT --to-port %u", FW_MARK_PROBATION,
+                            proxy_port);
+    }
 
-	iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_KNOWN);
-	iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_PROBATION);
-	iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
+    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_KNOWN);
+    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j ACCEPT", FW_MARK_PROBATION);
+    iptables_do_command("-t nat -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
 
-	iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_GLOBAL);
+    iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_GLOBAL);
     if (got_authdown_ruleset) {
         iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -j " CHAIN_AUTH_IS_DOWN);
         iptables_do_command("-t nat -A " CHAIN_AUTH_IS_DOWN " -m mark --mark 0x%u -j ACCEPT", FW_MARK_AUTH_IS_DOWN);
     }
     iptables_do_command("-t nat -A " CHAIN_UNKNOWN " -p tcp --dport 80 -j REDIRECT --to-ports %d", gw_port);
 
+    /*
+     *
+     * Everything in the FILTER table
+     *
+     */
 
-	/*
-	 *
-	 * Everything in the FILTER table
-	 *
-	 */
-
-	/* Create new chains */
-	iptables_do_command("-t filter -N " CHAIN_TO_INTERNET);
-	iptables_do_command("-t filter -N " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t filter -N " CHAIN_LOCKED);
-	iptables_do_command("-t filter -N " CHAIN_GLOBAL);
-	iptables_do_command("-t filter -N " CHAIN_VALIDATE);
-	iptables_do_command("-t filter -N " CHAIN_KNOWN);
-	iptables_do_command("-t filter -N " CHAIN_UNKNOWN);
+    /* Create new chains */
+    iptables_do_command("-t filter -N " CHAIN_TO_INTERNET);
+    iptables_do_command("-t filter -N " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t filter -N " CHAIN_LOCKED);
+    iptables_do_command("-t filter -N " CHAIN_GLOBAL);
+    iptables_do_command("-t filter -N " CHAIN_VALIDATE);
+    iptables_do_command("-t filter -N " CHAIN_KNOWN);
+    iptables_do_command("-t filter -N " CHAIN_UNKNOWN);
     if (got_authdown_ruleset)
         iptables_do_command("-t filter -N " CHAIN_AUTH_IS_DOWN);
 
-	/* Assign links and rules to these new chains */
+    /* Assign links and rules to these new chains */
 
-	/* Insert at the beginning */
-	iptables_do_command("-t filter -I FORWARD -i %s -j " CHAIN_TO_INTERNET, config->gw_interface);
+    /* Insert at the beginning */
+    iptables_do_command("-t filter -I FORWARD -i %s -j " CHAIN_TO_INTERNET, config->gw_interface);
 
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state INVALID -j DROP");
+    /* XXX: Why this? it means that connections setup after authentication
+       stay open even after the connection is done... 
+       iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state RELATED,ESTABLISHED -j ACCEPT"); */
 
-	/* XXX: Why this? it means that connections setup after authentication
-	   stay open even after the connection is done... 
-	   iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m state --state RELATED,ESTABLISHED -j ACCEPT");*/
+    //Won't this rule NEVER match anyway?!?!? benoitg, 2007-06-23
+    //iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -i %s -m state --state NEW -j DROP", ext_interface);
 
-	//Won't this rule NEVER match anyway?!?!? benoitg, 2007-06-23
-	//iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -i %s -m state --state NEW -j DROP", ext_interface);
+    /* TCPMSS rule for PPPoE */
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET
+                        " -o %s -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu", ext_interface);
 
-	/* TCPMSS rule for PPPoE */
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -o %s -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu", ext_interface);
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_AUTHSERVERS);
+    iptables_fw_set_authservers();
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_AUTHSERVERS);
-	iptables_fw_set_authservers();
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_LOCKED, FW_MARK_LOCKED);
+    iptables_load_ruleset("filter", FWRULESET_LOCKED_USERS, CHAIN_LOCKED);
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_LOCKED, FW_MARK_LOCKED);
-	iptables_load_ruleset("filter", FWRULESET_LOCKED_USERS, CHAIN_LOCKED);
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_GLOBAL);
+    iptables_load_ruleset("filter", FWRULESET_GLOBAL, CHAIN_GLOBAL);
+    iptables_load_ruleset("nat", FWRULESET_GLOBAL, CHAIN_GLOBAL);
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_GLOBAL);
-	iptables_load_ruleset("filter", FWRULESET_GLOBAL, CHAIN_GLOBAL);
-	iptables_load_ruleset("nat", FWRULESET_GLOBAL, CHAIN_GLOBAL);
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_VALIDATE, FW_MARK_PROBATION);
+    iptables_load_ruleset("filter", FWRULESET_VALIDATING_USERS, CHAIN_VALIDATE);
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_VALIDATE, FW_MARK_PROBATION);
-	iptables_load_ruleset("filter", FWRULESET_VALIDATING_USERS, CHAIN_VALIDATE);
-
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_KNOWN, FW_MARK_KNOWN);
-	iptables_load_ruleset("filter", FWRULESET_KNOWN_USERS, CHAIN_KNOWN);
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_KNOWN, FW_MARK_KNOWN);
+    iptables_load_ruleset("filter", FWRULESET_KNOWN_USERS, CHAIN_KNOWN);
 
     if (got_authdown_ruleset) {
-        iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_AUTH_IS_DOWN, FW_MARK_AUTH_IS_DOWN);
+        iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -m mark --mark 0x%u -j " CHAIN_AUTH_IS_DOWN,
+                            FW_MARK_AUTH_IS_DOWN);
         iptables_load_ruleset("filter", FWRULESET_AUTH_IS_DOWN, CHAIN_AUTH_IS_DOWN);
     }
 
-	iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
-	iptables_load_ruleset("filter", FWRULESET_UNKNOWN_USERS, CHAIN_UNKNOWN);
-	iptables_do_command("-t filter -A " CHAIN_UNKNOWN " -j REJECT --reject-with icmp-port-unreachable");
+    iptables_do_command("-t filter -A " CHAIN_TO_INTERNET " -j " CHAIN_UNKNOWN);
+    iptables_load_ruleset("filter", FWRULESET_UNKNOWN_USERS, CHAIN_UNKNOWN);
+    iptables_do_command("-t filter -A " CHAIN_UNKNOWN " -j REJECT --reject-with icmp-port-unreachable");
 
-	UNLOCK_CONFIG();
+    UNLOCK_CONFIG();
 
-	free(ext_interface);
-	return 1;
+    free(ext_interface);
+    return 1;
 }
 
 /** Remove the firewall rules
  * This is used when we do a clean shutdown of WiFiDog and when it starts to make
  * sure there are no rules left over
  */
-	int
+int
 iptables_fw_destroy(void)
 {
     int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
-	fw_quiet = 1;
+    fw_quiet = 1;
 
-	debug(LOG_DEBUG, "Destroying our iptables entries");
+    debug(LOG_DEBUG, "Destroying our iptables entries");
 
-	/*
-	 *
-	 * Everything in the MANGLE table
-	 *
-	 */
-	debug(LOG_DEBUG, "Destroying chains in the MANGLE table");
-	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TRUSTED);
-	iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_OUTGOING);
+    /*
+     *
+     * Everything in the MANGLE table
+     *
+     */
+    debug(LOG_DEBUG, "Destroying chains in the MANGLE table");
+    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_TRUSTED);
+    iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_OUTGOING);
     if (got_authdown_ruleset)
         iptables_fw_destroy_mention("mangle", "PREROUTING", CHAIN_AUTH_IS_DOWN);
-	iptables_fw_destroy_mention("mangle", "POSTROUTING", CHAIN_INCOMING);
-	iptables_do_command("-t mangle -F " CHAIN_TRUSTED);
-	iptables_do_command("-t mangle -F " CHAIN_OUTGOING);
+    iptables_fw_destroy_mention("mangle", "POSTROUTING", CHAIN_INCOMING);
+    iptables_do_command("-t mangle -F " CHAIN_TRUSTED);
+    iptables_do_command("-t mangle -F " CHAIN_OUTGOING);
     if (got_authdown_ruleset)
         iptables_do_command("-t mangle -F " CHAIN_AUTH_IS_DOWN);
-	iptables_do_command("-t mangle -F " CHAIN_INCOMING);
-	iptables_do_command("-t mangle -X " CHAIN_TRUSTED);
-	iptables_do_command("-t mangle -X " CHAIN_OUTGOING);
+    iptables_do_command("-t mangle -F " CHAIN_INCOMING);
+    iptables_do_command("-t mangle -X " CHAIN_TRUSTED);
+    iptables_do_command("-t mangle -X " CHAIN_OUTGOING);
     if (got_authdown_ruleset)
         iptables_do_command("-t mangle -X " CHAIN_AUTH_IS_DOWN);
-	iptables_do_command("-t mangle -X " CHAIN_INCOMING);
+    iptables_do_command("-t mangle -X " CHAIN_INCOMING);
 
-	/*
-	 *
-	 * Everything in the NAT table
-	 *
-	 */
-	debug(LOG_DEBUG, "Destroying chains in the NAT table");
-	iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_OUTGOING);
-	iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t nat -F " CHAIN_OUTGOING);
+    /*
+     *
+     * Everything in the NAT table
+     *
+     */
+    debug(LOG_DEBUG, "Destroying chains in the NAT table");
+    iptables_fw_destroy_mention("nat", "PREROUTING", CHAIN_OUTGOING);
+    iptables_do_command("-t nat -F " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t nat -F " CHAIN_OUTGOING);
     if (got_authdown_ruleset)
         iptables_do_command("-t nat -F " CHAIN_AUTH_IS_DOWN);
-	iptables_do_command("-t nat -F " CHAIN_TO_ROUTER);
-	iptables_do_command("-t nat -F " CHAIN_TO_INTERNET);
-	iptables_do_command("-t nat -F " CHAIN_GLOBAL);
-	iptables_do_command("-t nat -F " CHAIN_UNKNOWN);
-	iptables_do_command("-t nat -X " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t nat -X " CHAIN_OUTGOING);
+    iptables_do_command("-t nat -F " CHAIN_TO_ROUTER);
+    iptables_do_command("-t nat -F " CHAIN_TO_INTERNET);
+    iptables_do_command("-t nat -F " CHAIN_GLOBAL);
+    iptables_do_command("-t nat -F " CHAIN_UNKNOWN);
+    iptables_do_command("-t nat -X " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t nat -X " CHAIN_OUTGOING);
     if (got_authdown_ruleset)
         iptables_do_command("-t nat -X " CHAIN_AUTH_IS_DOWN);
-	iptables_do_command("-t nat -X " CHAIN_TO_ROUTER);
-	iptables_do_command("-t nat -X " CHAIN_TO_INTERNET);
-	iptables_do_command("-t nat -X " CHAIN_GLOBAL);
-	iptables_do_command("-t nat -X " CHAIN_UNKNOWN);
+    iptables_do_command("-t nat -X " CHAIN_TO_ROUTER);
+    iptables_do_command("-t nat -X " CHAIN_TO_INTERNET);
+    iptables_do_command("-t nat -X " CHAIN_GLOBAL);
+    iptables_do_command("-t nat -X " CHAIN_UNKNOWN);
 
-	/*
-	 *
-	 * Everything in the FILTER table
-	 *
-	 */
-	debug(LOG_DEBUG, "Destroying chains in the FILTER table");
-	iptables_fw_destroy_mention("filter", "FORWARD", CHAIN_TO_INTERNET);
-	iptables_do_command("-t filter -F " CHAIN_TO_INTERNET);
-	iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t filter -F " CHAIN_LOCKED);
-	iptables_do_command("-t filter -F " CHAIN_GLOBAL);
-	iptables_do_command("-t filter -F " CHAIN_VALIDATE);
-	iptables_do_command("-t filter -F " CHAIN_KNOWN);
-	iptables_do_command("-t filter -F " CHAIN_UNKNOWN);
+    /*
+     *
+     * Everything in the FILTER table
+     *
+     */
+    debug(LOG_DEBUG, "Destroying chains in the FILTER table");
+    iptables_fw_destroy_mention("filter", "FORWARD", CHAIN_TO_INTERNET);
+    iptables_do_command("-t filter -F " CHAIN_TO_INTERNET);
+    iptables_do_command("-t filter -F " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t filter -F " CHAIN_LOCKED);
+    iptables_do_command("-t filter -F " CHAIN_GLOBAL);
+    iptables_do_command("-t filter -F " CHAIN_VALIDATE);
+    iptables_do_command("-t filter -F " CHAIN_KNOWN);
+    iptables_do_command("-t filter -F " CHAIN_UNKNOWN);
     if (got_authdown_ruleset)
         iptables_do_command("-t filter -F " CHAIN_AUTH_IS_DOWN);
-	iptables_do_command("-t filter -X " CHAIN_TO_INTERNET);
-	iptables_do_command("-t filter -X " CHAIN_AUTHSERVERS);
-	iptables_do_command("-t filter -X " CHAIN_LOCKED);
-	iptables_do_command("-t filter -X " CHAIN_GLOBAL);
-	iptables_do_command("-t filter -X " CHAIN_VALIDATE);
-	iptables_do_command("-t filter -X " CHAIN_KNOWN);
-	iptables_do_command("-t filter -X " CHAIN_UNKNOWN);
+    iptables_do_command("-t filter -X " CHAIN_TO_INTERNET);
+    iptables_do_command("-t filter -X " CHAIN_AUTHSERVERS);
+    iptables_do_command("-t filter -X " CHAIN_LOCKED);
+    iptables_do_command("-t filter -X " CHAIN_GLOBAL);
+    iptables_do_command("-t filter -X " CHAIN_VALIDATE);
+    iptables_do_command("-t filter -X " CHAIN_KNOWN);
+    iptables_do_command("-t filter -X " CHAIN_UNKNOWN);
     if (got_authdown_ruleset)
         iptables_do_command("-t filter -X " CHAIN_AUTH_IS_DOWN);
 
-	return 1;
+    return 1;
 }
 
 /*
@@ -497,112 +496,113 @@ iptables_fw_destroy(void)
  * @param mention A word to find and delete in rules in the given table+chain
  */
 int
-iptables_fw_destroy_mention(
-		const char * table,
-		const char * chain,
-		const char * mention
-		) {
-	FILE *p = NULL;
-	char *command = NULL;
-	char *command2 = NULL;
-	char line[MAX_BUF];
-	char rulenum[10];
-	char *victim = safe_strdup(mention);
-	int deleted = 0;
+iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention)
+{
+    FILE *p = NULL;
+    char *command = NULL;
+    char *command2 = NULL;
+    char line[MAX_BUF];
+    char rulenum[10];
+    char *victim = safe_strdup(mention);
+    int deleted = 0;
 
-	iptables_insert_gateway_id(&victim);
+    iptables_insert_gateway_id(&victim);
 
-	debug(LOG_DEBUG, "Attempting to destroy all mention of %s from %s.%s", victim, table, chain);
+    debug(LOG_DEBUG, "Attempting to destroy all mention of %s from %s.%s", victim, table, chain);
 
-	safe_asprintf(&command, "iptables -t %s -L %s -n --line-numbers -v", table, chain);
-	iptables_insert_gateway_id(&command);
+    safe_asprintf(&command, "iptables -t %s -L %s -n --line-numbers -v", table, chain);
+    iptables_insert_gateway_id(&command);
 
-	if ((p = popen(command, "r"))) {
-		/* Skip first 2 lines */
-		while (!feof(p) && fgetc(p) != '\n');
-		while (!feof(p) && fgetc(p) != '\n');
-		/* Loop over entries */
-		while (fgets(line, sizeof(line), p)) {
-			/* Look for victim */
-			if (strstr(line, victim)) {
-				/* Found victim - Get the rule number into rulenum*/
-				if (sscanf(line, "%9[0-9]", rulenum) == 1) {
-					/* Delete the rule: */
-					debug(LOG_DEBUG, "Deleting rule %s from %s.%s because it mentions %s", rulenum, table, chain, victim);
-					safe_asprintf(&command2, "-t %s -D %s %s", table, chain, rulenum);
-					iptables_do_command(command2);
-					free(command2);
-					deleted = 1;
-					/* Do not keep looping - the captured rulenums will no longer be accurate */
-					break;
-				}
-			}
-		}
-		pclose(p);
-	}
+    if ((p = popen(command, "r"))) {
+        /* Skip first 2 lines */
+        while (!feof(p) && fgetc(p) != '\n') ;
+        while (!feof(p) && fgetc(p) != '\n') ;
+        /* Loop over entries */
+        while (fgets(line, sizeof(line), p)) {
+            /* Look for victim */
+            if (strstr(line, victim)) {
+                /* Found victim - Get the rule number into rulenum */
+                if (sscanf(line, "%9[0-9]", rulenum) == 1) {
+                    /* Delete the rule: */
+                    debug(LOG_DEBUG, "Deleting rule %s from %s.%s because it mentions %s", rulenum, table, chain,
+                          victim);
+                    safe_asprintf(&command2, "-t %s -D %s %s", table, chain, rulenum);
+                    iptables_do_command(command2);
+                    free(command2);
+                    deleted = 1;
+                    /* Do not keep looping - the captured rulenums will no longer be accurate */
+                    break;
+                }
+            }
+        }
+        pclose(p);
+    }
 
-	free(command);
-	free(victim);
+    free(command);
+    free(victim);
 
-	if (deleted) {
-		/* Recurse just in case there are more in the same table+chain */
-		iptables_fw_destroy_mention(table, chain, mention);
-	}
+    if (deleted) {
+        /* Recurse just in case there are more in the same table+chain */
+        iptables_fw_destroy_mention(table, chain, mention);
+    }
 
-	return (deleted);
+    return (deleted);
 }
 
 /** Set if a specific client has access through the firewall */
-	int
+int
 iptables_fw_access(fw_access_t type, const char *ip, const char *mac, int tag)
 {
-	int rc;
+    int rc;
 
-	fw_quiet = 0;
+    fw_quiet = 0;
 
-	switch(type) {
-		case FW_ACCESS_ALLOW:
-			iptables_do_command("-t mangle -A " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip, mac, tag);
-			rc = iptables_do_command("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
-			break;
-		case FW_ACCESS_DENY:
-			iptables_do_command("-t mangle -D " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip, mac, tag);
-			rc = iptables_do_command("-t mangle -D " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
-			break;
-		default:
-			rc = -1;
-			break;
-	}
+    switch (type) {
+    case FW_ACCESS_ALLOW:
+        iptables_do_command("-t mangle -A " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
+                            mac, tag);
+        rc = iptables_do_command("-t mangle -A " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
+        break;
+    case FW_ACCESS_DENY:
+        /* XXX Add looping to really clear? */
+        iptables_do_command("-t mangle -D " CHAIN_OUTGOING " -s %s -m mac --mac-source %s -j MARK --set-mark %d", ip,
+                            mac, tag);
+        rc = iptables_do_command("-t mangle -D " CHAIN_INCOMING " -d %s -j ACCEPT", ip);
+        break;
+    default:
+        rc = -1;
+        break;
+    }
 
-	return rc;
+    return rc;
 }
 
 int
 iptables_fw_access_host(fw_access_t type, const char *host)
 {
-	int rc;
+    int rc;
 
-	fw_quiet = 0;
+    fw_quiet = 0;
 
-	switch(type) {
-		case FW_ACCESS_ALLOW:
-			iptables_do_command("-t nat -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-			rc = iptables_do_command("-t filter -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-			break;
-		case FW_ACCESS_DENY:
-			iptables_do_command("-t nat -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-			rc = iptables_do_command("-t filter -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
-			break;
-		default:
-			rc = -1;
-			break;
-	}
+    switch (type) {
+    case FW_ACCESS_ALLOW:
+        iptables_do_command("-t nat -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+        rc = iptables_do_command("-t filter -A " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+        break;
+    case FW_ACCESS_DENY:
+        iptables_do_command("-t nat -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+        rc = iptables_do_command("-t filter -D " CHAIN_GLOBAL " -d %s -j ACCEPT", host);
+        break;
+    default:
+        rc = -1;
+        break;
+    }
 
-	return rc;
+    return rc;
 }
 
 /** Set a mark when auth server is not reachable */
-	int
+int
 iptables_fw_auth_unreachable(int tag)
 {
     int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
@@ -613,7 +613,7 @@ iptables_fw_auth_unreachable(int tag)
 }
 
 /** Remove mark when auth server is reachable again */
-	int
+int
 iptables_fw_auth_reachable(void)
 {
     int got_authdown_ruleset = NULL == get_ruleset(FWRULESET_AUTH_IS_DOWN) ? 0 : 1;
@@ -624,102 +624,101 @@ iptables_fw_auth_reachable(void)
 }
 
 /** Update the counters of all the clients in the client list */
-	int
+int
 iptables_fw_counters_update(void)
 {
-	FILE *output;
-	char *script,
-	     ip[16],
-	     rc;
-	unsigned long long int counter;
-	t_client *p1;
-	struct in_addr tempaddr;
+    FILE *output;
+    char *script, ip[16], rc;
+    unsigned long long int counter;
+    t_client *p1;
+    struct in_addr tempaddr;
 
-	/* Look for outgoing traffic */
-	safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_OUTGOING);
-	iptables_insert_gateway_id(&script);
-	output = popen(script, "r");
-	free(script);
-	if (!output) {
-		debug(LOG_ERR, "popen(): %s", strerror(errno));
-		return -1;
-	}
+    /* Look for outgoing traffic */
+    safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_OUTGOING);
+    iptables_insert_gateway_id(&script);
+    output = popen(script, "r");
+    free(script);
+    if (!output) {
+        debug(LOG_ERR, "popen(): %s", strerror(errno));
+        return -1;
+    }
 
-	/* skip the first two lines */
-	while (('\n' != fgetc(output)) && !feof(output))
-		;
-	while (('\n' != fgetc(output)) && !feof(output))
-		;
-	while (output && !(feof(output))) {
-		rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s %*s", &counter, ip);
-		//rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s 0x%*u", &counter, ip);
-		if (2 == rc && EOF != rc) {
-			/* Sanity*/
-			if (!inet_aton(ip, &tempaddr)) {
-				debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
-				continue;
-			}
-			debug(LOG_DEBUG, "Read outgoing traffic for %s: Bytes=%llu", ip, counter);
-			LOCK_CLIENT_LIST();
-			if ((p1 = client_list_find_by_ip(ip))) {
-				if ((p1->counters.outgoing - p1->counters.outgoing_history) < counter) {
-					p1->counters.outgoing = p1->counters.outgoing_history + counter;
-					p1->counters.last_updated = time(NULL);
-					debug(LOG_DEBUG, "%s - Updated counter.outgoing to %llu bytes.  Updated last_updated to %d", ip, counter, p1->counters.last_updated);
-				}
-			} else {
-				debug(LOG_ERR, "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed", ip);
-				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
-				iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
-				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
-				iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
-			}
-			UNLOCK_CLIENT_LIST();
-		}
-	}
-	pclose(output);
+    /* skip the first two lines */
+    while (('\n' != fgetc(output)) && !feof(output)) ;
+    while (('\n' != fgetc(output)) && !feof(output)) ;
+    while (output && !(feof(output))) {
+        rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s %*s", &counter, ip);
+        //rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %15[0-9.] %*s %*s %*s %*s %*s 0x%*u", &counter, ip);
+        if (2 == rc && EOF != rc) {
+            /* Sanity */
+            if (!inet_aton(ip, &tempaddr)) {
+                debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
+                continue;
+            }
+            debug(LOG_DEBUG, "Read outgoing traffic for %s: Bytes=%llu", ip, counter);
+            LOCK_CLIENT_LIST();
+            if ((p1 = client_list_find_by_ip(ip))) {
+                if ((p1->counters.outgoing - p1->counters.outgoing_history) < counter) {
+                    p1->counters.outgoing = p1->counters.outgoing_history + counter;
+                    p1->counters.last_updated = time(NULL);
+                    debug(LOG_DEBUG, "%s - Updated counter.outgoing to %llu bytes.  Updated last_updated to %d", ip,
+                          counter, p1->counters.last_updated);
+                }
+            } else {
+                debug(LOG_ERR,
+                      "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
+                      ip);
+                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
+                iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
+                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
+                iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
+            }
+            UNLOCK_CLIENT_LIST();
+        }
+    }
+    pclose(output);
 
-	/* Look for incoming traffic */
-	safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_INCOMING);
-	iptables_insert_gateway_id(&script);
-	output = popen(script, "r");
-	free(script);
-	if (!output) {
-		debug(LOG_ERR, "popen(): %s", strerror(errno));
-		return -1;
-	}
+    /* Look for incoming traffic */
+    safe_asprintf(&script, "%s %s", "iptables", "-v -n -x -t mangle -L " CHAIN_INCOMING);
+    iptables_insert_gateway_id(&script);
+    output = popen(script, "r");
+    free(script);
+    if (!output) {
+        debug(LOG_ERR, "popen(): %s", strerror(errno));
+        return -1;
+    }
 
-	/* skip the first two lines */
-	while (('\n' != fgetc(output)) && !feof(output))
-		;
-	while (('\n' != fgetc(output)) && !feof(output))
-		;
-	while (output && !(feof(output))) {
-		rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %*s %15[0-9.]", &counter, ip);
-		if (2 == rc && EOF != rc) {
-			/* Sanity*/
-			if (!inet_aton(ip, &tempaddr)) {
-				debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
-				continue;
-			}
-			debug(LOG_DEBUG, "Read incoming traffic for %s: Bytes=%llu", ip, counter);
-			LOCK_CLIENT_LIST();
-			if ((p1 = client_list_find_by_ip(ip))) {
-				if ((p1->counters.incoming - p1->counters.incoming_history) < counter) {
-					p1->counters.incoming = p1->counters.incoming_history + counter;
-					debug(LOG_DEBUG, "%s - Updated counter.incoming to %llu bytes", ip, counter);
-				}
-			} else {
-				debug(LOG_ERR, "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed", ip);
-				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
-				iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
-				debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
-				iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
-			}
-			UNLOCK_CLIENT_LIST();
-		}
-	}
-	pclose(output);
+    /* skip the first two lines */
+    while (('\n' != fgetc(output)) && !feof(output)) ;
+    while (('\n' != fgetc(output)) && !feof(output)) ;
+    while (output && !(feof(output))) {
+        rc = fscanf(output, "%*s %llu %*s %*s %*s %*s %*s %*s %15[0-9.]", &counter, ip);
+        if (2 == rc && EOF != rc) {
+            /* Sanity */
+            if (!inet_aton(ip, &tempaddr)) {
+                debug(LOG_WARNING, "I was supposed to read an IP address but instead got [%s] - ignoring it", ip);
+                continue;
+            }
+            debug(LOG_DEBUG, "Read incoming traffic for %s: Bytes=%llu", ip, counter);
+            LOCK_CLIENT_LIST();
+            if ((p1 = client_list_find_by_ip(ip))) {
+                if ((p1->counters.incoming - p1->counters.incoming_history) < counter) {
+                    p1->counters.incoming = p1->counters.incoming_history + counter;
+                    debug(LOG_DEBUG, "%s - Updated counter.incoming to %llu bytes", ip, counter);
+                }
+            } else {
+                debug(LOG_ERR,
+                      "iptables_fw_counters_update(): Could not find %s in client list, this should not happen unless if the gateway crashed",
+                      ip);
+                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_OUTGOING);
+                iptables_fw_destroy_mention("mangle", CHAIN_OUTGOING, ip);
+                debug(LOG_ERR, "Preventively deleting firewall rules for %s in table %s", ip, CHAIN_INCOMING);
+                iptables_fw_destroy_mention("mangle", CHAIN_INCOMING, ip);
+            }
+            UNLOCK_CLIENT_LIST();
+        }
+    }
+    pclose(output);
 
-	return 1;
+    return 1;
 }

--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -1,3 +1,4 @@
+/* vim: set et ts=4 sts=4 sw=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *

--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -29,7 +29,7 @@
 
 #include "firewall.h"
 
-/*@{*/ 
+/*@{*/
 /**Iptable chain names used by WifiDog */
 #define CHAIN_OUTGOING  "WiFiDog_$ID$_Outgoing"
 #define CHAIN_TO_INTERNET "WiFiDog_$ID$_Internet"
@@ -43,7 +43,7 @@
 #define CHAIN_LOCKED    "WiFiDog_$ID$_Locked"
 #define CHAIN_TRUSTED    "WiFiDog_$ID$_Trusted"
 #define CHAIN_AUTH_IS_DOWN "WiFiDog_$ID$_AuthIsDown"
-/*@}*/ 
+/*@}*/
 
 /** Used by iptables_fw_access to select if the client should be granted of denied access */
 typedef enum fw_access_t_ {
@@ -64,7 +64,7 @@ void iptables_fw_clear_authservers(void);
 int iptables_fw_destroy(void);
 
 /** @brief Helper function for iptables_fw_destroy */
-int iptables_fw_destroy_mention( const char * table, const char * chain, const char * mention);
+int iptables_fw_destroy_mention(const char *table, const char *chain, const char *mention);
 
 /** @brief Define the access of a specific client */
 int iptables_fw_access(fw_access_t type, const char *ip, const char *mac, int tag);
@@ -81,4 +81,4 @@ int iptables_fw_auth_reachable(void);
 /** @brief All counters in the client list */
 int iptables_fw_counters_update(void);
 
-#endif /* _IPTABLES_H_ */
+#endif                          /* _IPTABLES_H_ */

--- a/src/http.c
+++ b/src/http.c
@@ -279,7 +279,7 @@ http_callback_auth(httpd * webserver, request * r)
                 char *urlFragment = NULL;
                 t_auth_serv *auth_server = get_auth_server();
 
-                fw_deny(client->ip, client->mac, client->fw_connection_state);
+                fw_deny(client, client->fw_connection_state);
                 client_list_delete(client);
                 debug(LOG_DEBUG, "Got logout from %s", ip);
 

--- a/src/http.c
+++ b/src/http.c
@@ -269,7 +269,7 @@ http_callback_auth(httpd * webserver, request * r)
 
             if ((client = client_list_find(r->clientAddr, mac)) == NULL) {
                 debug(LOG_DEBUG, "New client for %s", r->clientAddr);
-                client_list_append(r->clientAddr, mac, token->value);
+                client_list_add(r->clientAddr, mac, token->value);
             } else if (logout) {
                 t_authresponse authresponse;
                 s_config *config = config_get_config();

--- a/src/http.c
+++ b/src/http.c
@@ -279,7 +279,7 @@ http_callback_auth(httpd * webserver, request * r)
                 char *urlFragment = NULL;
                 t_auth_serv *auth_server = get_auth_server();
 
-                fw_deny(client, client->fw_connection_state);
+                fw_deny(client);
                 client_list_delete(client);
                 debug(LOG_DEBUG, "Got logout from %s", ip);
 

--- a/src/util.c
+++ b/src/util.c
@@ -435,7 +435,8 @@ get_status_text()
         pstr_append_sprintf(pstr, "\nClient %d\n", count);
         pstr_append_sprintf(pstr, "  IP: %s MAC: %s\n", first->ip, first->mac);
         pstr_append_sprintf(pstr, "  Token: %s\n", first->token);
-        pstr_append_sprintf(pstr, "  Downloaded: %llu\n  Uploaded: %llu\n", first->counters.incoming, first->counters.outgoing);
+        pstr_append_sprintf(pstr, "  Downloaded: %llu\n  Uploaded: %llu\n", first->counters.incoming,
+                            first->counters.outgoing);
 
         count++;
         first = first->next;
@@ -475,11 +476,11 @@ init_icmp_socket(void)
     int flags, oneopt = 1, zeroopt = 0;
 
     debug(LOG_INFO, "Creating ICMP socket");
-    if ((icmp_fd = socket (AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1 ||
-            (flags = fcntl(icmp_fd, F_GETFL, 0)) == -1 ||
-             fcntl(icmp_fd, F_SETFL, flags | O_NONBLOCK) == -1 ||
-             setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &oneopt, sizeof(oneopt)) ||
-             setsockopt(icmp_fd, SOL_SOCKET, SO_DONTROUTE, &zeroopt, sizeof(zeroopt)) == -1) {
+    if ((icmp_fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1 ||
+        (flags = fcntl(icmp_fd, F_GETFL, 0)) == -1 ||
+        fcntl(icmp_fd, F_SETFL, flags | O_NONBLOCK) == -1 ||
+        setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &oneopt, sizeof(oneopt)) ||
+        setsockopt(icmp_fd, SOL_SOCKET, SO_DONTROUTE, &zeroopt, sizeof(zeroopt)) == -1) {
         debug(LOG_ERR, "Cannot create ICMP raw socket.");
         return 0;
     }
@@ -501,46 +502,46 @@ close_icmp_socket(void)
 void
 icmp_ping(const char *host)
 {
-	struct sockaddr_in saddr;
-	struct {
-		struct ip ip;
-		struct icmp icmp;
-	} packet;
-	unsigned int i, j;
-	int opt = 2000;
-	unsigned short id = rand16();
+    struct sockaddr_in saddr;
+    struct {
+        struct ip ip;
+        struct icmp icmp;
+    } packet;
+    unsigned int i, j;
+    int opt = 2000;
+    unsigned short id = rand16();
 
-	memset(&saddr, 0, sizeof(saddr));
-	saddr.sin_family = AF_INET;
-	inet_aton(host, &saddr.sin_addr);
+    memset(&saddr, 0, sizeof(saddr));
+    saddr.sin_family = AF_INET;
+    inet_aton(host, &saddr.sin_addr);
 #if defined(HAVE_SOCKADDR_SA_LEN)
-	saddr.sin_len = sizeof(struct sockaddr_in);
+    saddr.sin_len = sizeof(struct sockaddr_in);
 #endif
 
-	memset(&packet.icmp, 0, sizeof(packet.icmp));
-	packet.icmp.icmp_type = ICMP_ECHO;
-	packet.icmp.icmp_id = id;
+    memset(&packet.icmp, 0, sizeof(packet.icmp));
+    packet.icmp.icmp_type = ICMP_ECHO;
+    packet.icmp.icmp_id = id;
 
-	for (j = 0, i = 0; i < sizeof(struct icmp) / 2; i++)
-		j += ((unsigned short *)&packet.icmp)[i];
+    for (j = 0, i = 0; i < sizeof(struct icmp) / 2; i++)
+        j += ((unsigned short *)&packet.icmp)[i];
 
-	while (j >> 16)
-		j = (j & 0xffff) + (j >> 16);
+    while (j >> 16)
+        j = (j & 0xffff) + (j >> 16);
 
-	packet.icmp.icmp_cksum = (j == 0xffff) ? j : ~j;
+    packet.icmp.icmp_cksum = (j == 0xffff) ? j : ~j;
 
-	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
-		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
+    if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
+        debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
 
-	if (sendto(icmp_fd, (char *)&packet.icmp, sizeof(struct icmp), 0,
-	           (const struct sockaddr *)&saddr, sizeof(saddr)) == -1)
-		debug(LOG_ERR, "sendto(): %s", strerror(errno));
+    if (sendto(icmp_fd, (char *)&packet.icmp, sizeof(struct icmp), 0,
+               (const struct sockaddr *)&saddr, sizeof(saddr)) == -1)
+        debug(LOG_ERR, "sendto(): %s", strerror(errno));
 
-	opt = 1;
-	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
-		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
+    opt = 1;
+    if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
+        debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
 
-	return;
+    return;
 }
 
 /** Get a 16-bit unsigned random number.
@@ -564,8 +565,8 @@ rand16(void)
     }
 
     /* Some rand() implementations have less randomness in low bits
-    * than in high bits, so we only pay attention to the high ones.
-    * But most implementations don't touch the high bit, so we
-    * ignore that one. */
-    return((unsigned short)(rand() >> 15));
+     * than in high bits, so we only pay attention to the high ones.
+     * But most implementations don't touch the high bit, so we
+     * ignore that one. */
+    return ((unsigned short)(rand() >> 15));
 }

--- a/src/util.c
+++ b/src/util.c
@@ -46,6 +46,12 @@
 #include <netinet/in.h>
 #include <net/if.h>
 
+#include <fcntl.h>
+#include <net/ethernet.h>
+#include <netinet/ip.h>
+#include <netinet/ip_icmp.h>
+#include <netpacket/packet.h>
+
 #include <string.h>
 #include <pthread.h>
 #include <netdb.h>
@@ -62,6 +68,10 @@
 
 #include "../config.h"
 
+/** @brief FD for icmp raw socket */
+static int icmp_fd;
+
+/** @brief Mutex to protect gethostbyname since not reentrant */
 static pthread_mutex_t ghbn_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* XXX Do these need to be locked ? */
@@ -71,6 +81,8 @@ static time_t last_auth_online_time = 0;
 static time_t last_auth_offline_time = 0;
 
 long served_this_session = 0;
+
+static unsigned short rand16(void);
 
 /** Fork a child and execute a shell command, the parent
  * process waits for the child to return and returns the child's exit()
@@ -452,4 +464,108 @@ get_status_text()
     UNLOCK_CONFIG();
 
     return pstr_to_string(pstr);
+}
+
+/** Initialize the ICMP socket
+ * @return A boolean of the success
+ */
+int
+init_icmp_socket(void)
+{
+    int flags, oneopt = 1, zeroopt = 0;
+
+    debug(LOG_INFO, "Creating ICMP socket");
+    if ((icmp_fd = socket (AF_INET, SOCK_RAW, IPPROTO_ICMP)) == -1 ||
+            (flags = fcntl(icmp_fd, F_GETFL, 0)) == -1 ||
+             fcntl(icmp_fd, F_SETFL, flags | O_NONBLOCK) == -1 ||
+             setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &oneopt, sizeof(oneopt)) ||
+             setsockopt(icmp_fd, SOL_SOCKET, SO_DONTROUTE, &zeroopt, sizeof(zeroopt)) == -1) {
+        debug(LOG_ERR, "Cannot create ICMP raw socket.");
+        return 0;
+    }
+    return 1;
+}
+
+/** Close the ICMP socket. */
+void
+close_icmp_socket(void)
+{
+    debug(LOG_INFO, "Closing ICMP socket");
+    close(icmp_fd);
+}
+
+/**
+ * Ping an IP.
+ * @param IP/host as string, will be sent to gethostbyname
+ */
+void
+icmp_ping(const char *host)
+{
+	struct sockaddr_in saddr;
+	struct {
+		struct ip ip;
+		struct icmp icmp;
+	} packet;
+	unsigned int i, j;
+	int opt = 2000;
+	unsigned short id = rand16();
+
+	memset(&saddr, 0, sizeof(saddr));
+	saddr.sin_family = AF_INET;
+	inet_aton(host, &saddr.sin_addr);
+#if defined(HAVE_SOCKADDR_SA_LEN)
+	saddr.sin_len = sizeof(struct sockaddr_in);
+#endif
+
+	memset(&packet.icmp, 0, sizeof(packet.icmp));
+	packet.icmp.icmp_type = ICMP_ECHO;
+	packet.icmp.icmp_id = id;
+
+	for (j = 0, i = 0; i < sizeof(struct icmp) / 2; i++)
+		j += ((unsigned short *)&packet.icmp)[i];
+
+	while (j >> 16)
+		j = (j & 0xffff) + (j >> 16);
+
+	packet.icmp.icmp_cksum = (j == 0xffff) ? j : ~j;
+
+	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
+		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
+
+	if (sendto(icmp_fd, (char *)&packet.icmp, sizeof(struct icmp), 0,
+	           (const struct sockaddr *)&saddr, sizeof(saddr)) == -1)
+		debug(LOG_ERR, "sendto(): %s", strerror(errno));
+
+	opt = 1;
+	if (setsockopt(icmp_fd, SOL_SOCKET, SO_RCVBUF, &opt, sizeof(opt)) == -1)
+		debug(LOG_ERR, "setsockopt(): %s", strerror(errno));
+
+	return;
+}
+
+/** Get a 16-bit unsigned random number.
+ * @return unsigned short a random number
+ */
+static unsigned short
+rand16(void)
+{
+    static int been_seeded = 0;
+
+    if (!been_seeded) {
+        unsigned int seed = 0;
+        struct timeval now;
+
+        /* not a very good seed but what the heck, it needs to be quickly acquired */
+        gettimeofday(&now, NULL);
+        seed = now.tv_sec ^ now.tv_usec ^ (getpid() << 16);
+
+        srand(seed);
+        been_seeded = 1;
+    }
+
+    /* Some rand() implementations have less randomness in low bits
+    * than in high bits, so we only pay attention to the high ones.
+    * But most implementations don't touch the high bit, so we
+    * ignore that one. */
+    return((unsigned short)(rand() >> 15));
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,4 @@
+/* vim: set et ts=4 sts=4 sw=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -29,40 +30,53 @@
 
 #define STATUS_BUF_SIZ	16384
 
+/** @brief Client server this session. */
 extern long served_this_session;
 
-/** @brief Execute a shell command
- */
-int execute(const char *cmd_line, int quiet);
-struct in_addr *wd_gethostbyname(const char *name);
+/** @brief Execute a shell command */
+int execute(const char *, int);
 
-/* @brief Get IP address of an interface */
-char *get_iface_ip(const char *ifname);
+/** @brief Thread safe gethostbyname */
+struct in_addr *wd_gethostbyname(const char *);
 
-/* @brief Get MAC address of an interface */
-char *get_iface_mac(const char *ifname);
+/** @brief Get IP address of an interface */
+char *get_iface_ip(const char *);
 
-/* @brief Get interface name of default gateway */
-char *get_ext_iface (void);
+/** @brief Get MAC address of an interface */
+char *get_iface_mac(const char *);
 
-/* @brief Sets hint that an online action (dns/connect/etc using WAN) succeeded */
+/** @brief Get interface name of default gateway */
+char *get_ext_iface(void);
+
+/** @brief Sets hint that an online action (dns/connect/etc using WAN) succeeded */
 void mark_online(void);
-/* @brief Sets hint that an online action (dns/connect/etc using WAN) failed */
+
+/** @brief Sets hint that an online action (dns/connect/etc using WAN) failed */
 void mark_offline(void);
-/* @brief Returns a guess (true or false) on whether we're online or not based on previous calls to mark_online and mark_offline */
+
+/** @brief Returns a guess (true or false) on whether we're online or not based on previous calls to mark_online and mark_offline */
 int is_online(void);
 
-/* @brief Sets hint that an auth server online action succeeded */
+/** @brief Sets hint that an auth server online action succeeded */
 void mark_auth_online(void);
-/* @brief Sets hint that an auth server online action failed */
+
+/** @brief Sets hint that an auth server online action failed */
 void mark_auth_offline(void);
-/* @brief Returns a guess (true or false) on whether we're an auth server is online or not based on previous calls to mark_auth_online and mark_auth_offline */
+
+/** @brief Returns a guess (true or false) on whether we're an auth server is online or not based on previous calls to mark_auth_online and mark_auth_offline */
 int is_auth_online(void);
 
-/*
- * @brief Creates a human-readable paragraph of the status of wifidog
- */
+/** @brief Creates a human-readable paragraph of the status of wifidog */
 char * get_status_text(void);
+
+/** @brief Initialize the ICMP socket */
+int init_icmp_socket(void);
+
+/** @brief Close the ICMP socket. */
+void close_icmp_socket(void);
+
+/** @brief ICMP Ping an IP */
+void icmp_ping(const char *);
 
 #define LOCK_GHBN() do { \
 	debug(LOG_DEBUG, "Locking wd_gethostbyname()"); \

--- a/src/util.h
+++ b/src/util.h
@@ -67,7 +67,7 @@ void mark_auth_offline(void);
 int is_auth_online(void);
 
 /** @brief Creates a human-readable paragraph of the status of wifidog */
-char * get_status_text(void);
+char *get_status_text(void);
 
 /** @brief Initialize the ICMP socket */
 int init_icmp_socket(void);
@@ -90,5 +90,4 @@ void icmp_ping(const char *);
 	debug(LOG_DEBUG, "wd_gethostbyname() unlocked"); \
 } while (0)
 
-#endif /* _UTIL_H_ */
-
+#endif                          /* _UTIL_H_ */

--- a/src/wdctl_thread.c
+++ b/src/wdctl_thread.c
@@ -355,8 +355,8 @@ wdctl_restart(int afd)
     } else {
         /* Child */
         close(wdctl_socket_server);
-        close(icmp_fd);
         close(sock);
+        close_icmp_socket();
         shutdown(afd, 2);
         close(afd);
         debug(LOG_NOTICE, "Re-executing myself (%s)", restartargv[0]);


### PR DESCRIPTION
This code needs a lot of testing and probably has remaining bugs but it attempts to avoid being affected by client_list changes in any way.

The trick is that the entire client list gets duplicated and the mutex is dropped and then the copy is processed.

Mutex are re-acquired and the client refound (by mac and ip) before being changed. Explicit checks exist for client that no longer exist.

This aims at resolving #84 