### PR TITLE
Prevent possible leaks

### DIFF
--- a/src/gateway.c
+++ b/src/gateway.c
@@ -475,6 +475,9 @@ main_loop(void)
             /* webserver->lastError should be 2 */
             /* XXX We failed an ACL.... No handling because
              * we don't set any... */
+            if (NULL != r) {
+                httpdEndRequest(r);
+            }
         }
     }
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -443,7 +443,9 @@ main_loop(void)
          * values that are not -1, 0 or 1. */
         if (webserver->lastError == -1) {
             /* Interrupted system call */
-            continue;           /* restart loop */
+            if (NULL != r) {
+                httpdEndRequest(r);
+            }
         } else if (webserver->lastError < -1) {
             /*
              * FIXME


### PR DESCRIPTION
In some error scenarios, HTTP `request` objects could not have been freed.

Prompted by `valgrind` results from #34 