### PR TITLE
Refactor main() to allow for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 .DS_Store
 *.o
+*.a
 *.la
 *.so
 *.lo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,8 @@
 # $Id$
 #
 
+noinst_LIBRARIES = libgateway.a
+
 bin_PROGRAMS = wifidog \
 	wdctl
  
@@ -11,9 +13,11 @@ AM_CPPFLAGS = \
 	-Wall \
 	-Wextra \
 	-Wno-unused-parameter
-wifidog_LDADD = $(top_builddir)/libhttpd/libhttpd.la
+wifidog_LDADD = libgateway.a $(top_builddir)/libhttpd/libhttpd.la
 
-wifidog_SOURCES = commandline.c \
+wifidog_SOURCES = main.c
+
+libgateway_a_SOURCES = commandline.c \
 	conf.c \
 	debug.c \
 	fw_iptables.c \
@@ -50,5 +54,7 @@ noinst_HEADERS = commandline.h \
 	httpd_thread.h \
 	simple_http.h \
 	pstring.h
+
+wdctl_LDADD = libgateway.a
 
 wdctl_SOURCES = wdctl.c

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -19,7 +19,6 @@
  *                                                                  *
  \********************************************************************/
 
-/* $Id$ */
 /** @internal
   @file gateway.c
   @brief Main loop
@@ -483,7 +482,7 @@ main_loop(void)
 
 /** Reads the configuration file and then starts the main loop */
 int
-main(int argc, char **argv)
+gw_main(int argc, char **argv)
 {
 
     s_config *config = config_get_config();

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
- * published by the Free Software Foundation; either version 2 of   *
+ * published by the Free:Software Foundation; either version 2 of   *
  * the License, or (at your option) any later version.              *
  *                                                                  *
  * This program is distributed in the hope that it will be useful,  *
@@ -17,30 +17,18 @@
  * 59 Temple Place - Suite 330        Fax:    +1-617-542-2652       *
  * Boston, MA  02111-1307,  USA       gnu@gnu.org                   *
  *                                                                  *
-\********************************************************************/
+ \********************************************************************/
 
-/* $Id$ */
-/** @file gateway.h
-    @brief Main loop
-    @author Copyright (C) 2004 Philippe April <papril777@yahoo.com>
-*/
+/** @internal
+  @file main.c
+  @brief Entry point only
+  @author Copyright (C) 2015 Alexandre Carmel-Veilleux <acv@miniguru.ca>
+ */
 
-#ifndef _GATEWAY_H_
-#define _GATEWAY_H_
+#include "gateway.h"
 
-#include <stdio.h>
-
-#include "httpd.h"
-
-extern time_t started_time;
-
-/** @brief The internal web server */
-extern httpd *webserver;
-
-/** @brief actual program entry point. */
-int gw_main(int, char **);
-
-/** @brief exits cleanly and clear the firewall rules. */
-void termination_handler(int s);
-
-#endif                          /* _GATEWAY_H_ */
+int
+main(int argc, char **argv)
+{
+    return gw_main(argc, argv);
+}


### PR DESCRIPTION
`main.c` only contains `main()` and calls `gateway.c:gw_main()` as its sole action.

The rest of the source files now build into `libgateway.a` which is linked into everything else.

Eventually, this will allow unit tests to be linked against `libgateway.a` using the `check` unit testing framework.