### PR TITLE
Fix missing error recovery in libhttpd/api.c

### DIFF
--- a/libhttpd/api.c
+++ b/libhttpd/api.c
@@ -311,7 +311,8 @@ struct timeval *timeout;
     socklen_t addrLen;
     char *ipaddr;
     request *r;
-
+    /* Reset error */
+    server->lastError = 0;
     FD_ZERO(&fds);
     FD_SET(server->serverSock, &fds);
     result = 0;


### PR DESCRIPTION
The select call sometimes may be interrupted or otherwise return
a value < 0. In this case, we do want to signal an error to the caller.

For subsequent calls, the error need to be reset or the caller (gateway.c)
will keep going into the error handler path even though the HTTP request
was handled succesfully.