### PR TITLE
Child return value not checked properly

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -118,7 +118,12 @@ execute(const char *cmd_line, int quiet)
     rc = waitpid(pid, &status, 0);
     debug(LOG_DEBUG, "Process PID %d exited", rc);
 
-    return (WEXITSTATUS(status));
+    if (WIFEXITED(status)) {
+        return (WEXITSTATUS(status));
+    } else {
+        /* If we get here, child did not exit cleanly. Will return non-zero exit code to caller*/
+        return 1;
+    }
 }
 
 struct in_addr *


### PR DESCRIPTION
`util.c:execute()` now handles child that die, closes #175

If the child dies due to a signal or similar, the return code is not available through the `WEXITSTATUS()` macro. We check this by first doing `WIFEXITED()`.

From man page:

>        WEXITSTATUS(status)
>              returns the exit status of the child.  This consists of the least significant 8 bits of the status argument that the child
>              specified  in  a  call  to  exit(3) or _exit(2) or as the argument for a return statement in main().  This macro should be
>              employed only if WIFEXITED returned true.
