### PR TITLE
Isolate debug from rest of gateway

### DIFF
--- a/src/commandline.c
+++ b/src/commandline.c
@@ -120,16 +120,17 @@ parse_commandline(int argc, char **argv)
         case 'f':
             skiponrestart = 1;
             config->daemon = 0;
+            debugconf.log_stderr = 1;
             break;
 
         case 'd':
             if (optarg) {
-                config->debuglevel = atoi(optarg);
+                debugconf.debuglevel = atoi(optarg);
             }
             break;
 
         case 's':
-            config->log_syslog = 1;
+            debugconf.log_syslog = 1;
             break;
 
         case 'v':

--- a/src/conf.c
+++ b/src/conf.c
@@ -171,7 +171,6 @@ config_init(void)
     debug(LOG_DEBUG, "Setting default config parameters");
     config.configfile = safe_strdup(DEFAULT_CONFIGFILE);
     config.htmlmsgfile = safe_strdup(DEFAULT_HTMLMSGFILE);
-    config.debuglevel = DEFAULT_DEBUGLEVEL;
     config.httpdmaxconn = DEFAULT_HTTPDMAXCONN;
     config.external_interface = NULL;
     config.gw_id = DEFAULT_GATEWAYID;
@@ -185,9 +184,7 @@ config_init(void)
     config.httpdpassword = NULL;
     config.clienttimeout = DEFAULT_CLIENTTIMEOUT;
     config.checkinterval = DEFAULT_CHECKINTERVAL;
-    config.syslog_facility = DEFAULT_SYSLOG_FACILITY;
     config.daemon = -1;
-    config.log_syslog = DEFAULT_LOG_SYSLOG;
     config.wdctl_sock = safe_strdup(DEFAULT_WDCTL_SOCK);
     config.internal_sock = safe_strdup(DEFAULT_INTERNAL_SOCK);
     config.rulesets = NULL;
@@ -197,6 +194,11 @@ config_init(void)
     config.ssl_verify = DEFAULT_AUTHSERVSSLPEERVER;
     config.ssl_cipher_list = NULL;
     config.arp_table_path = safe_strdup(DEFAULT_ARPTABLE);
+
+    debugconf.log_stderr = 1;
+    debugconf.debuglevel = DEFAULT_DEBUGLEVEL;
+    debugconf.syslog_facility = DEFAULT_SYSLOG_FACILITY;
+    debugconf.log_syslog = DEFAULT_LOG_SYSLOG;
 }
 
 /**
@@ -205,8 +207,12 @@ config_init(void)
 void
 config_init_override(void)
 {
-    if (config.daemon == -1)
+    if (config.daemon == -1) {
         config.daemon = DEFAULT_DAEMON;
+        if (config.daemon > 0) {
+            debugconf.log_stderr = 0;
+        }
+    }
 }
 
 /** @internal
@@ -681,6 +687,11 @@ config_read(const char *filename)
                 case oDaemon:
                     if (config.daemon == -1 && ((value = parse_boolean_value(p1)) != -1)) {
                         config.daemon = value;
+                        if (config.daemon > 0) {
+                            debugconf.log_stderr = 0;
+                        } else {
+                            debugconf.log_stderr = 1;
+                        }
                     }
                     break;
                 case oExternalInterface:
@@ -733,7 +744,7 @@ config_read(const char *filename)
                     sscanf(p1, "%d", &config.clienttimeout);
                     break;
                 case oSyslogFacility:
-                    sscanf(p1, "%d", &config.syslog_facility);
+                    sscanf(p1, "%d", &debugconf.syslog_facility);
                     break;
                 case oHtmlMessageFile:
                     config.htmlmsgfile = safe_strdup(p1);

--- a/src/conf.h
+++ b/src/conf.h
@@ -158,7 +158,6 @@ typedef struct {
     char *wdctl_sock;           /**< @brief wdctl path to socket */
     char *internal_sock;                /**< @brief internal path to socket */
     int daemon;                 /**< @brief if daemon > 0, use daemon mode */
-    int debuglevel;             /**< @brief Debug information verbosity */
     char *external_interface;   /**< @brief External network interface name for
 				     firewall rules */
     char *gw_id;                /**< @brief ID of the Gateway, sent to central
@@ -180,9 +179,6 @@ typedef struct {
 				     must be re-authenticated */
     int checkinterval;          /**< @brief Frequency the the client timeout check
 				     thread will run. */
-    int log_syslog;             /**< @brief boolean, wether to log to syslog */
-    int syslog_facility;        /**< @brief facility to use when using syslog for
-				     logging */
     int proxy_port;             /**< @brief Transparent proxy port (0 to disable) */
     char *ssl_certs;            /**< @brief Path to SSL certs for auth server
 		verification */

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,3 +1,4 @@
+/* vim: set et ts=4 sts=4 sw=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -18,7 +19,6 @@
  *                                                                  *
 \********************************************************************/
 
-/* $Id$ */
 /** @file debug.c
     @brief Debug output routines
     @author Copyright (C) 2004 Philippe April <papril777@yahoo.com>
@@ -32,7 +32,9 @@
 #include <unistd.h>
 #include <signal.h>
 
-#include "conf.h"
+#include "debug.h"
+
+debugconf_t debugconf = {0, 0, 0, 0};
 
 /** @internal
 Do not use directly, use the debug macro */
@@ -41,40 +43,39 @@ _debug(const char *filename, int line, int level, const char *format, ...)
 {
     char buf[28];
     va_list vlist;
-    s_config *config = config_get_config();
     time_t ts;
     sigset_t block_chld;
 
     time(&ts);
 
-    if (config->debuglevel >= level) {
+    if (debugconf.debuglevel >= level) {
         sigemptyset(&block_chld);
         sigaddset(&block_chld, SIGCHLD);
         sigprocmask(SIG_BLOCK, &block_chld, NULL);
 
         if (level <= LOG_WARNING) {
             fprintf(stderr, "[%d][%.24s][%u](%s:%d) ", level, ctime_r(&ts, buf), getpid(),
-			    filename, line);
+                filename, line);
             va_start(vlist, format);
             vfprintf(stderr, format, vlist);
             va_end(vlist);
             fputc('\n', stderr);
-        } else if (!config->daemon) {
+        } else if (debugconf.log_stderr) {
             fprintf(stderr, "[%d][%.24s][%u](%s:%d) ", level, ctime_r(&ts, buf), getpid(),
-			    filename, line);
+                filename, line);
             va_start(vlist, format);
             vfprintf(stderr, format, vlist);
             va_end(vlist);
             fputc('\n', stderr);
         }
 
-        if (config->log_syslog) {
-            openlog("wifidog", LOG_PID, config->syslog_facility);
+        if (debugconf.log_syslog) {
+            openlog("wifidog", LOG_PID, debugconf.syslog_facility);
             va_start(vlist, format);
             vsyslog(level, format, vlist);
             va_end(vlist);
             closelog();
-	}
+        }
         
         sigprocmask(SIG_UNBLOCK, &block_chld, NULL);
     }

--- a/src/debug.c
+++ b/src/debug.c
@@ -34,7 +34,12 @@
 
 #include "debug.h"
 
-debugconf_t debugconf = {0, 0, 0, 0};
+debugconf_t debugconf = {
+    .debuglevel = LOG_INFO,
+    .log_stderr = 1,
+    .log_syslog = 0,
+    .syslog_facility = 0
+};
 
 /** @internal
 Do not use directly, use the debug macro */

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,3 +1,4 @@
+/* vim: set et ts=4 sts=4 sw=4 : */
 /********************************************************************\
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -18,7 +19,6 @@
  *                                                                  *
 \********************************************************************/
 
-/* $Id$ */
 /** @file debug.h
     @brief Debug output routines
     @author Copyright (C) 2004 Philippe April <papril777@yahoo.com>
@@ -27,12 +27,23 @@
 #ifndef _DEBUG_H_
 #define _DEBUG_H_
 
-/** @brief Used to output messages.
- *The messages will include the finlname and line number, and will be sent to syslog if so configured in the config file 
+typedef struct _debug_conf {
+    int debuglevel;      /**< @brief Debug information verbosity */
+    int log_stderr;      /**< @brief Output log to stdout */
+    int log_syslog;      /**< @brief Output log to syslog */
+    int syslog_facility; /**< @brief facility to use when using syslog for logging */
+} debugconf_t;
+
+extern debugconf_t debugconf;
+
+/** Used to output messages.
+ * The messages will include the filename and line number, and will be sent to syslog if so configured in the config file 
+ * @param level Debug level
+ * @param format... sprintf like format string
  */
 #define debug(level, format...) _debug(__FILE__, __LINE__, level, format)
 
 /** @internal */
-void _debug(const char *filename, int line, int level, const char *format, ...);
+void _debug(const char *, int, int, const char *, ...);
 
 #endif /* _DEBUG_H_ */


### PR DESCRIPTION
This is also to support the goal of extracting some C file into a common library and using them for both libhttpd and the gateway proper.