### PR TITLE
fix: change rindex to strrchr

### DIFF
--- a/libhttpd/api.c
+++ b/libhttpd/api.c
@@ -916,7 +916,7 @@ httpdSendFile(httpd * server, request * r, const char *path)
     char *suffix;
     struct stat sbuf;
 
-    suffix = rindex(path, '.');
+    suffix = strrchr(path, '.');
     if (suffix != NULL) {
         if (strcasecmp(suffix, ".gif") == 0)
             strcpy(r->response.contentType, "image/gif");


### PR DESCRIPTION
ChangeLog show this:

2009-11-03
	* Fix #625, does not display failure notice when quiet is set to true
	* Fix #587, change index and rindex to strchr and strrchr
	* Fix #548, trim leading spaces of the config file's options

now, #587 fixed again.