### PR TITLE
Fix for Android build

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -81,6 +81,10 @@
 /**
  * Mutex for the configuration file, used by the auth_servers related
  * functions. */
+// fix for Android build
+#ifdef __ANDROID__
+#include <pthread.h>
+#endif
 extern pthread_mutex_t config_mutex;
 
 /**


### PR DESCRIPTION
this is one of two patch for Android build. the another patch is https://github.com/wifidog/wifidog-gateway/pull/195

because configure.in check pthread with -lpthread and it will fail in NDK. so, I modify configure.in 

``` patch
diff --git a/configure.in b/configure.in
index 33c585d..edceb72 100644
--- a/configure.in
+++ b/configure.in
@@ -105,7 +105,7 @@ BB_CYASSL

 # check for pthread
 AC_CHECK_HEADER(pthread.h, , AC_MSG_ERROR(You need the pthread headers) )
-AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(You need the pthread library) )
+#AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(You need the pthread library) )

 # libhttpd dependencies
 echo "Begining libhttpd dependencies check"
```
