### PR TITLE
Remove hardcoded servers

### DIFF
--- a/src/centralserver.c
+++ b/src/centralserver.c
@@ -159,15 +159,10 @@ _connect_auth_server(int level)
 {
     s_config *config = config_get_config();
     t_auth_serv *auth_server = NULL;
+    t_popular_server *popular_server = NULL;
     struct in_addr *h_addr;
     int num_servers = 0;
     char *hostname = NULL;
-    char *popular_servers[] = {
-        "www.google.com",
-        "www.yahoo.com",
-        NULL
-    };
-    char **popularserver;
     char *ip;
     struct sockaddr_in their_addr;
     int sockfd;
@@ -207,20 +202,18 @@ _connect_auth_server(int level)
     if (!h_addr) {
         /*
          * DNS resolving it failed
-         *
-         * Can we resolve any of the popular servers ?
          */
         debug(LOG_DEBUG, "Level %d: Resolving auth server [%s] failed", level, hostname);
 
-        for (popularserver = popular_servers; *popularserver; popularserver++) {
-            debug(LOG_DEBUG, "Level %d: Resolving popular server [%s]", level, *popularserver);
-            h_addr = wd_gethostbyname(*popularserver);
+        for (popular_server = config->popular_servers; popular_server; popular_server = popular_server->next) {
+            debug(LOG_DEBUG, "Level %d: Resolving popular server [%s]", level, popular_server->hostname);
+            h_addr = wd_gethostbyname(popular_server->hostname);
             if (h_addr) {
-                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] succeeded = [%s]", level, *popularserver,
+                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] succeeded = [%s]", level, popular_server->hostname,
                       inet_ntoa(*h_addr));
                 break;
             } else {
-                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] failed", level, *popularserver);
+                debug(LOG_DEBUG, "Level %d: Resolving popular server [%s] failed", level, popular_server->hostname);
             }
         }
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -144,6 +144,14 @@ typedef struct _trusted_mac_t {
 } t_trusted_mac;
 
 /**
+ * Popular Servers
+ */
+typedef struct _popular_server_t {
+    char *hostname;
+    struct _popular_server_t *next;
+} t_popular_server;
+
+/**
  * Configuration structure
  */
 typedef struct {
@@ -183,6 +191,7 @@ typedef struct {
     t_trusted_mac *trustedmaclist; /**< @brief list of trusted macs */
     char *arp_table_path; /**< @brief Path to custom ARP table, formatted
         like /proc/net/arp */
+    t_popular_server *popular_servers; /**< @brief list of popular servers */
 } s_config;
 
 /** @brief Get the current gateway configuration */
@@ -210,6 +219,8 @@ void mark_auth_server_bad(t_auth_serv *);
 t_firewall_rule *get_ruleset(const char *);
 
 void parse_trusted_mac_list(const char *);
+
+void parse_popular_servers(const char *);
 
 #define LOCK_CONFIG() do { \
 	debug(LOG_DEBUG, "Locking config"); \

--- a/src/conf.h
+++ b/src/conf.h
@@ -218,9 +218,6 @@ void mark_auth_server_bad(t_auth_serv *);
 /** @brief Fetch a firewall rule set. */
 t_firewall_rule *get_ruleset(const char *);
 
-void parse_trusted_mac_list(const char *);
-
-void parse_popular_servers(const char *);
 
 #define LOCK_CONFIG() do { \
 	debug(LOG_DEBUG, "Locking config"); \

--- a/wifidog.conf
+++ b/wifidog.conf
@@ -221,6 +221,10 @@ ClientTimeout 5
 # Default: none
 # Optional
 #
+
+# Check DNS health by querying IPs of these hosts
+PopularServers kernel.org,ieee.org
+
 # Comma separated list of MAC addresses who are allowed to pass
 # through without authentication.
 # N.B.: weak security, since MAC addresses are easy to spoof.


### PR DESCRIPTION
This incorporate @sinkcup's changes and adds a default config and WARNING when no PopularServers are defined in config.

Also fixed parsing of the config when there were spaces.