### PR TITLE
Allow interface names longer then max chain

### DIFF
--- a/src/fw_iptables.c
+++ b/src/fw_iptables.c
@@ -71,6 +71,7 @@ iptables_insert_gateway_id(char **input)
     char *token;
     const s_config *config;
     char *buffer;
+    char *tmp_intf;
 
     if (strstr(*input, "$ID$") == NULL)
         return;
@@ -80,9 +81,14 @@ iptables_insert_gateway_id(char **input)
         memcpy(token, "%1$s", 4);
 
     config = config_get_config();
-    safe_asprintf(&buffer, *input, config->gw_interface);
+    tmp_intf = safe_strdup(config->gw_interface);
+    if (strlen(tmp_intf) > CHAIN_NAME_MAX_LEN) {
+        *(tmp_intf + CHAIN_NAME_MAX_LEN) = '\0';
+    }
+    safe_asprintf(&buffer, *input, tmp_intf);
 
-    free(*input);
+    free(tmp_intf);
+    free(*input);  /* Not an error, input from safe_asprintf */
     *input = buffer;
 }
 

--- a/src/fw_iptables.h
+++ b/src/fw_iptables.h
@@ -30,20 +30,22 @@
 
 #include "firewall.h"
 
+#define CHAIN_NAME_MAX_LEN 15  /* 28 (actual max) - 13 (AuthServers chain fixed part. */
+
 /*@{*/
 /**Iptable chain names used by WifiDog */
-#define CHAIN_OUTGOING  "WiFiDog_$ID$_Outgoing"
-#define CHAIN_TO_INTERNET "WiFiDog_$ID$_Internet"
-#define CHAIN_TO_ROUTER "WiFiDog_$ID$_Router"
-#define CHAIN_INCOMING  "WiFiDog_$ID$_Incoming"
-#define CHAIN_AUTHSERVERS "WiFiDog_$ID$_AuthServers"
-#define CHAIN_GLOBAL  "WiFiDog_$ID$_Global"
-#define CHAIN_VALIDATE  "WiFiDog_$ID$_Validate"
-#define CHAIN_KNOWN     "WiFiDog_$ID$_Known"
-#define CHAIN_UNKNOWN   "WiFiDog_$ID$_Unknown"
-#define CHAIN_LOCKED    "WiFiDog_$ID$_Locked"
-#define CHAIN_TRUSTED    "WiFiDog_$ID$_Trusted"
-#define CHAIN_AUTH_IS_DOWN "WiFiDog_$ID$_AuthIsDown"
+#define CHAIN_OUTGOING  "WD_$ID$_Outgoing"
+#define CHAIN_TO_INTERNET "WD_$ID$_Internet"
+#define CHAIN_TO_ROUTER "WD_$ID$_Router"
+#define CHAIN_INCOMING  "WD_$ID$_Incoming"
+#define CHAIN_AUTHSERVERS "WD_$ID$_AuthServs"  /* Longest chain, 13 chars ecluding ID */
+#define CHAIN_GLOBAL  "WD_$ID$_Global"
+#define CHAIN_VALIDATE  "WD_$ID$_Validate"
+#define CHAIN_KNOWN     "WD_$ID$_Known"
+#define CHAIN_UNKNOWN   "WD_$ID$_Unknown"
+#define CHAIN_LOCKED    "WD_$ID$_Locked"
+#define CHAIN_TRUSTED    "WD_$ID$_Trusted"
+#define CHAIN_AUTH_IS_DOWN "WD_$ID$_AuthDown"
 /*@}*/
 
 /** Used by iptables_fw_access to select if the client should be granted of denied access */


### PR DESCRIPTION
This is to fix issue #202 

The solution consists of:
1. Made the chain name shorter, they start by `WD_` instead of `WiFiDog_`
2. If the interface name is still too long, it's truncated so the sting is still `<= 28` characters long.
