### PR TITLE
Add SSLUseSNI support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -94,6 +94,26 @@ if test "x$enable_cyassl" = xyes; then
         AC_SEARCH_LIBS([CyaSSLv23_client_method], [cyassl wolfssl], [], [
                 AC_MSG_ERROR([unable to find the CyaSSLv23_client_method function.])
         ])
+
+        AC_MSG_CHECKING([for the CyaSSL SNI enabled])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM(
+        [[
+                #define HAVE_SNI
+                #include <cyassl/ssl.h>
+        ]], [[
+                CYASSL_CTX *ctx;
+                CyaSSL_Init();
+                ctx = CyaSSL_CTX_new(CyaTLSv1_client_method());
+                CyaSSL_CTX_UseSNI(ctx, CYASSL_SNI_HOST_NAME, "wifidog.org", 11);
+        ]])], [enabled_sni=yes], [enabled_sni=no])
+
+        if test "x$enabled_sni" = xyes; then
+                AC_MSG_RESULT([yes])
+                AC_DEFINE([HAVE_SNI],, "Compile with CyaSSL SNI support")
+        else
+                AC_MSG_RESULT([no])
+        fi
+
         AC_DEFINE(USE_CYASSL,, "Compile with CyaSSL support")
 fi
 ])

--- a/src/conf.c
+++ b/src/conf.c
@@ -103,6 +103,7 @@ typedef enum {
     oSSLPeerVerification,
     oSSLCertPath,
     oSSLAllowedCipherList,
+    oSSLUseSNI,
 } OpCodes;
 
 /** @internal
@@ -149,6 +150,7 @@ static const struct {
     "sslpeerverification", oSSLPeerVerification}, {
     "sslcertpath", oSSLCertPath}, {
     "sslallowedcipherlist", oSSLAllowedCipherList}, {
+    "sslusesni", oSSLUseSNI}, {
 NULL, oBadOption},};
 
 static void config_notnull(const void *, const char *);
@@ -204,6 +206,7 @@ config_init(void)
     config.deltatraffic = DEFAULT_DELTATRAFFIC;
     config.ssl_cipher_list = NULL;
     config.arp_table_path = safe_strdup(DEFAULT_ARPTABLE);
+    config.ssl_use_sni = DEFAULT_AUTHSERVSSLSNI;
 
     debugconf.log_stderr = 1;
     debugconf.debuglevel = DEFAULT_DEBUGLEVEL;
@@ -789,6 +792,17 @@ config_read(const char *filename)
                     config.ssl_cipher_list = safe_strdup(p1);
 #ifndef USE_CYASSL
                     debug(LOG_WARNING, "SSLAllowedCipherList is set but no SSL compiled in. Ignoring!");
+#endif
+                    break;
+                case oSSLUseSNI:
+                    config.ssl_use_sni = parse_boolean_value(p1);
+                    if (config.ssl_use_sni < 0) {
+                        debug(LOG_WARNING, "Bad syntax for Parameter: SSLUseSNI on line %d " "in %s."
+                            "The syntax is yes or no." , linenum, filename);
+                        exit(-1);
+                    }
+#ifndef USE_CYASSL
+                    debug(LOG_WARNING, "SSLUseSNI is set but no SSL compiled in. Ignoring!");
 #endif
                     break;
                 case oBadOption:

--- a/src/conf.c
+++ b/src/conf.c
@@ -803,6 +803,10 @@ config_read(const char *filename)
                     }
 #ifndef USE_CYASSL
                     debug(LOG_WARNING, "SSLUseSNI is set but no SSL compiled in. Ignoring!");
+#else
+#ifndef HAVE_SNI
+                    debug(LOG_WARNING, "SSLUseSNI is set but no CyaSSL SNI enabled. Ignoring!");
+#endif
 #endif
                     break;
                 case oBadOption:

--- a/src/conf.h
+++ b/src/conf.h
@@ -67,6 +67,7 @@
 #define DEFAULT_AUTHSERVSSLPEERVER 1    /* 0 means: Enable peer verification */
 #define DEFAULT_DELTATRAFFIC 0    /* 0 means: Enable peer verification */
 #define DEFAULT_ARPTABLE "/proc/net/arp"
+#define DEFAULT_AUTHSERVSSLSNI 0  /* 0 means: Disable SNI */
 /*@}*/
 
 /*@{*/
@@ -189,6 +190,8 @@ typedef struct {
     int ssl_verify;             /**< @brief boolean, whether to enable
 		auth server certificate verification */
     char *ssl_cipher_list;  /**< @brief List of SSL ciphers allowed. Optional. */
+    int ssl_use_sni;            /**< @brief boolean, whether to enable
+    auth server for server name indication, the TLS extension */
     t_firewall_ruleset *rulesets;       /**< @brief firewall rules */
     t_trusted_mac *trustedmaclist; /**< @brief list of trusted macs */
     char *arp_table_path; /**< @brief Path to custom ARP table, formatted

--- a/src/simple_http.c
+++ b/src/simple_http.c
@@ -46,7 +46,7 @@
 #endif
 
 #ifdef USE_CYASSL
-static CYASSL_CTX *get_cyassl_ctx(void);
+static CYASSL_CTX *get_cyassl_ctx(const char *hostname);
 #endif
 
 /**
@@ -151,7 +151,7 @@ static pthread_mutex_t cyassl_ctx_mutex = PTHREAD_MUTEX_INITIALIZER;
 } while (0)
 
 static CYASSL_CTX *
-get_cyassl_ctx(void)
+get_cyassl_ctx(const char *hostname)
 {
     int err;
     CYASSL_CTX *ret;
@@ -174,6 +174,19 @@ get_cyassl_ctx(void)
             err = CyaSSL_CTX_set_cipher_list(cyassl_ctx, config->ssl_cipher_list);
             if (SSL_SUCCESS != err) {
                 debug(LOG_ERR, "Could not load SSL cipher list (error %d)", err);
+                UNLOCK_CYASSL_CTX();
+                return NULL;
+            }
+        }
+
+        if (config->ssl_use_sni) {
+            debug(LOG_INFO, "Setting SSL using SNI for hostname %s",
+                hostname);
+            err = CyaSSL_CTX_UseSNI(cyassl_ctx, CYASSL_SNI_HOST_NAME, hostname,
+                      strlen(hostname));
+            if (SSL_SUCCESS != err) {
+                debug(LOG_ERR, "Could not setup SSL using SNI for hostname %s",
+                    hostname);
                 UNLOCK_CYASSL_CTX();
                 return NULL;
             }
@@ -233,7 +246,7 @@ https_get(const int sockfd, const char *req, const char *hostname)
     s_config *config;
     config = config_get_config();
 
-    ctx = get_cyassl_ctx();
+    ctx = get_cyassl_ctx(hostname);
     if (NULL == ctx) {
         debug(LOG_ERR, "Could not get CyaSSL Context!");
         goto error;

--- a/src/simple_http.c
+++ b/src/simple_http.c
@@ -179,6 +179,7 @@ get_cyassl_ctx(const char *hostname)
             }
         }
 
+#ifdef HAVE_SNI
         if (config->ssl_use_sni) {
             debug(LOG_INFO, "Setting SSL using SNI for hostname %s",
                 hostname);
@@ -191,6 +192,7 @@ get_cyassl_ctx(const char *hostname)
                 return NULL;
             }
         }
+#endif
 
         if (config->ssl_verify) {
             /* Use trusted certs */

--- a/wifidog.conf
+++ b/wifidog.conf
@@ -225,6 +225,20 @@ ClientTimeout 5
 #
 # SSLAllowedCipherList ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:ECDH-ECDSA-AES128-GCM-SHA256:ECDH-ECDSA-AES256-GCM-SHA384:ECDH-RSA-AES128-GCM-SHA256:ECDH-RSA-AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:ECDH-ECDSA-AES128-SHA:ECDH-ECDSA-AES256-SHA:ECDH-RSA-AES128-SHA:ECDH-RSA-AES256-SHA:AES128-SHA:AES256-SHA
 
+# Parameter: SSLUseSNI
+# Default: no
+# Optional
+#
+# Enable SNI (Server Name Indication) TLS extension.
+# Enabling this setting is mainly useful if the auth server is hosted
+# multiple secure (HTTPS) websites. The WifiDog should indicate which hostname
+# it is attempting to connect to at the start of the handshaking process.
+#
+# This setting requires that WifiDog is compiled with SSL support.
+# It will be ignored otherwise.
+#
+# SSLUseSNI no
+
 # Parameter: TrustedMACList
 # Default: none
 # Optional


### PR DESCRIPTION
* The TLS extension - SNI (Server Name Indication) is required for the
  auth server that hosted multiple secure (HTTPS) websites.

  see: https://en.wikipedia.org/wiki/Server_Name_Indication

  The SSLUseSNI field was added to the configuration file as an
  optional, default is "no" SNI setup.