### PR TITLE
fix bug of getting Gateway value & bug of missing parameter 'level'

### DIFF
--- a/src/centralserver.c
+++ b/src/centralserver.c
@@ -319,7 +319,7 @@ _connect_auth_server(int level)
         free(h_addr);
 
         if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-            debug(LOG_ERR, "Level %d: Failed to create a new SOCK_STREAM socket: %s", strerror(errno));
+            debug(LOG_ERR, "Level %d: Failed to create a new SOCK_STREAM socket: %s", level, strerror(errno));
             return (-1);
         }
 

--- a/src/util.c
+++ b/src/util.c
@@ -252,7 +252,7 @@ get_ext_iface(void)
         }
         while (!feof(input)) {
             /* XXX scanf(3) is unsafe, risks overrun */
-            if ((fscanf(input, "%15s %15s %*s %*s %*s %*s %*s %*s %*s %*s %*s\n", device, gw) == 2)
+            if ((fscanf(input, "%15s %*s %15s %*s %*s %*s %*s %*s %*s %*s %*s\n", device, gw) == 2)
                 && strcmp(gw, "00000000") == 0) {
                 free(gw);
                 debug(LOG_INFO, "get_ext_iface(): Detected %s as the default interface after trying %d", device, i);


### PR DESCRIPTION
fix 2 bugs:
1.fix the bug of getting the valule of Gateway mistakenly from the valule of Destination;
2.fix the bug of missing parameter "level" 