### PR TITLE
Implementation of 511 Network Authentication

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -234,17 +234,10 @@ void
 http_send_redirect(request * r, const char *url, const char *text)
 {
     char *message = NULL;
-    char *header = NULL;
-    char *response = NULL;
     /* Re-direct them to auth server */
     debug(LOG_DEBUG, "Redirecting client browser to %s", url);
-    safe_asprintf(&header, "Location: %s", url);
-    safe_asprintf(&response, "302 %s\n", text ? text : "Redirecting");
-    httpdSetResponse(r, response);
-    httpdAddHeader(r, header);
-    free(response);
-    free(header);
-    safe_asprintf(&message, "Please <a href='%s'>click here</a>.", url);
+    httpdSetResponse(r, "511 Network Authentication Required");
+    safe_asprintf(&message, "The maintainers of this network need you to signin. Please <a href='%s'>click here</a>.", url);
     send_http_page(r, text ? text : "Redirection to message", message);
     free(message);
 }

--- a/src/http.c
+++ b/src/http.c
@@ -237,7 +237,7 @@ http_send_redirect(request * r, const char *url, const char *text)
     /* Re-direct them to auth server */
     debug(LOG_DEBUG, "Redirecting client browser to %s", url);
     httpdSetResponse(r, "511 Network Authentication Required");
-    safe_asprintf(&message, "The maintainers of this network need you to signin. Please <a href='%s'>click here</a>.", url);
+    safe_asprintf(&message, "<meta http-equiv='refresh' content='0; url=%s'>The maintainers of this network need you to sign in. Please <a href='%s'>click here</a>.", url, url);
     send_http_page(r, text ? text : "Redirection to message", message);
     free(message);
 }


### PR DESCRIPTION
Hi,

RFC #6585, defines a new response reader, code 511 Network Authentication Required, its purpose is "mitigate problems caused by captive portals".

All requests answered with 511 will not be cached and is this is the only way for the client machine to identify an hotspot and auto redirect to login page. Windows and Apple OSX automatically detect it.

One of my main issues running wifidog is make the user redirected to login, this fix it.

Thank you.