### PR TITLE
fix compilation with modern wolfSSL

### DIFF
--- a/src/simple_http.c
+++ b/src/simple_http.c
@@ -28,6 +28,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <unistd.h>
+#include <pthread.h>
 #include <string.h>
 #include <syslog.h>
 
@@ -37,6 +38,7 @@
 #include "pstring.h"
 
 #ifdef USE_CYASSL
+#include <cyassl/options.h>
 #include <cyassl/ssl.h>
 #include "conf.h"
 /* For CYASSL_MAX_ERROR_SZ */


### PR DESCRIPTION
options.h needs to be the first header from wolfSSL.

pthread.h is implicitly included with glibc's unistd.h but not musl's.