### PR TITLE
Adding checks for null return value of malloc

### DIFF
--- a/libhttpd/api.c
+++ b/libhttpd/api.c
@@ -168,6 +168,8 @@ httpdAddVariable(request * r, const char *name, const char *value)
     while (*name == ' ' || *name == '\t')
         name++;
     newVar = malloc(sizeof(httpVar));
+    if (newVar == NULL)
+        return (NULL);
     bzero(newVar, sizeof(httpVar));
     newVar->name = strdup(name);
     newVar->value = strdup(value);
@@ -215,6 +217,8 @@ int port;
     else
         new->host = strdup(host);
     new->content = (httpDir *) malloc(sizeof(httpDir));
+    if (new->content == NULL)
+        return (NULL);
     bzero(new->content, sizeof(httpDir));
     new->content->name = strdup("");
 

--- a/libhttpd/ip_acl.c
+++ b/libhttpd/ip_acl.c
@@ -149,6 +149,8 @@ int action;
         cur = cur->next;
     } else {
         cur = (httpAcl *) malloc(sizeof(httpAcl));
+        if (cur == NULL)
+            return (NULL);
         acl = cur;
     }
 

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -523,7 +523,7 @@ gw_main(int argc, char **argv)
             sleep(1);
         }
 
-        debug(LOG_INFO, "Parent PID %d seems to be dead. Continuing loading.");
+        debug(LOG_INFO, "Parent PID %d seems to be dead. Continuing loading.", restart_orig_pid);
     }
 
     if (config->daemon) {


### PR DESCRIPTION
The results of these malloc calls are not checked for null, but 72% of calls to malloc check for null.